### PR TITLE
feat: Add dynamic toggle to the hero CTA button when logged in

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -55,7 +55,7 @@
       Discover courses, meetups, workshops, and study groups — all on a platform where every piece of user data is encrypted at rest.
     </p>
     <div class="flex flex-col sm:flex-row gap-4 justify-center">
-      <a href="/login.html?tab=register" class="bg-white text-brand font-bold px-8 py-3 rounded-xl shadow hover:bg-indigo-50 transition">Join Free</a>
+      <a id="hero-cta" href="/login.html?tab=register" class="bg-white text-brand font-bold px-8 py-3 rounded-xl shadow hover:bg-indigo-50 transition">Join Free</a>
       <a href="#activities" class="border border-white/50 text-white font-semibold px-8 py-3 rounded-xl hover:bg-white/10 transition">Browse Activities</a>
     </div>
   </div>
@@ -165,7 +165,29 @@
         <a href="/login.html?tab=register" class="bg-brand text-white text-sm font-semibold px-4 py-1.5 rounded-lg hover:bg-brand-dark transition">Register</a>`;
     }
   }
-  function logout() { localStorage.removeItem('edu_token'); localStorage.removeItem('edu_user'); updateNav(); }
+
+  function updateHeroCta() {
+    const token = localStorage.getItem('edu_token');
+    const user  = JSON.parse(localStorage.getItem('edu_user') || 'null');
+    const heroCta = document.getElementById('hero-cta');
+    if (!heroCta) return;
+    
+    if (token && user) {
+      heroCta.href = '/dashboard.html';
+      heroCta.textContent = 'Go to Dashboard';
+    } else {
+      heroCta.href = '/login.html?tab=register';
+      heroCta.textContent = 'Join Free';
+    }
+  }
+
+  function logout() { 
+    localStorage.removeItem('edu_token'); 
+    localStorage.removeItem('edu_user'); 
+    updateNav(); 
+    updateHeroCta(); 
+  }
+  
   function esc(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
 
   // ── Colours
@@ -272,6 +294,7 @@
     document.getElementById(id).addEventListener(id === 'search' ? 'input' : 'change', renderGrid));
 
   updateNav();
+  updateHeroCta();
   loadActivities();
 </script>
 </body>


### PR DESCRIPTION
# Abstract

Hi, this PR introduces a minor but important UX improvement to the homepage.
Previously, the main CTA (call-to-action) button in the `Hero` section always prompted the user to "Join Free" and directed them to the registration page, even if they were already authenticated. 

This PR fixes that by dynamically updating the button's text and destination based on the user's login state.

# Changes

- **Dynamic CTA State public/index.html:** 
  - Implemented the `updateHeroCta()` function that checks `localStorage` for the active `edu_token` and `edu_user`.
  - When a user is **logged in**, the hero CTA button automatically changes its text to "Go to Dashboard" and routes to `/dashboard.html`.
  - When a user is **logged out** (or guest), it defaults back to "Join Free" and routes to `/login.html?tab=register`.
- **Event Binding:** Ensured the new function is called smoothly upon page load and correctly reverts state during the `logout()` action.

<img width="1398" height="638" alt="image" src="https://github.com/user-attachments/assets/b5d10d4b-b136-42ca-af36-3929703c98a8" />

https://github.com/user-attachments/assets/00feab8f-b9e0-4f82-bff7-cb2cae1591f7

# Impact

Improves the frontend navigation flow for returning users by allowing them to jump straight into their dashboard directly from the hero banner, rather than manually navigating through the authentication pages. No backend or API changes were required. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Purpose
Add dynamic hero CTA button behavior that adapts based on user authentication state, improving navigation flow for both new and returning users on the landing page.

## Key Changes
- **Added updateHeroCta() function** in public/index.html that dynamically updates the hero CTA button text and destination based on authentication status:
  - **Logged-in users**: CTA displays "Go to Dashboard" and links to `/dashboard.html`
  - **Logged-out users**: CTA displays "Join Free" and links to `/login.html?tab=register`
- **Integrated into page lifecycle**: Function is invoked on initial page load to ensure correct state on first visit, and called within the `logout()` function to reset the CTA when users sign out
- **Storage-based state detection**: Leverages existing `localStorage` keys (`edu_token` and `edu_user`) to determine authentication status

## Impact
- **User Experience**: Reduces friction for returning users by providing direct dashboard access from the hero section without requiring navigation through intermediate pages
- **Scope**: Client-side DOM manipulation only—no backend or API changes required
- **Code Changes**: 25 lines added, 2 lines modified

<!-- end of auto-generated comment: release notes by coderabbit.ai -->