### PR TITLE
Activity and Session Editable Functionality

### DIFF
--- a/public/teach.html
+++ b/public/teach.html
@@ -372,7 +372,7 @@
         return `<li class="px-4 py-2 flex justify-between items-center bg-white hover:bg-slate-50">
           <div>
             <span class="font-semibold text-slate-800">${esc(s.title)}</span>
-            <div class="text-xs text-slate-500">${s.start_time || ''}</div>
+            <div class="text-xs text-slate-500">${esc(s.start_time || '')}</div>
           </div>
           <button type="button" onclick="startEditSession('${esc(s.id)}')" class="text-xs text-brand font-semibold border border-brand/30 px-2 py-1 rounded hover:bg-indigo-50">Edit</button>
         </li>`;

--- a/public/teach.html
+++ b/public/teach.html
@@ -136,29 +136,29 @@
                 <label id="ses-fields-title" class="block text-sm font-semibold text-slate-800 mb-2">New Session Details</label>
               </div>
               <div>
-                <label class="block text-sm font-medium text-slate-700 mb-1">Session Title *</label>
+                <label for="s-title" class="block text-sm font-medium text-slate-700 mb-1">Session Title *</label>
                 <input id="s-title" type="text" required
                   class="w-full px-4 py-2.5 rounded-xl border border-slate-200 focus:outline-none focus:ring-2 focus:ring-brand/40 text-sm" placeholder="e.g. Week 1 - Introduction" />
               </div>
               <div class="grid grid-cols-2 gap-3 mt-3">
                 <div>
-                  <label class="block text-sm font-medium text-slate-700 mb-1">Start Time</label>
+                  <label for="s-start" class="block text-sm font-medium text-slate-700 mb-1">Start Time</label>
                   <input id="s-start" type="datetime-local"
                     class="w-full px-3 py-2.5 rounded-xl border border-slate-200 focus:outline-none focus:ring-2 focus:ring-brand/40 text-sm" />
                 </div>
                 <div>
-                  <label class="block text-sm font-medium text-slate-700 mb-1">End Time</label>
+                  <label for="s-end" class="block text-sm font-medium text-slate-700 mb-1">End Time</label>
                   <input id="s-end" type="datetime-local"
                     class="w-full px-3 py-2.5 rounded-xl border border-slate-200 focus:outline-none focus:ring-2 focus:ring-brand/40 text-sm" />
                 </div>
               </div>
               <div class="mt-3">
-                <label class="block text-sm font-medium text-slate-700 mb-1">Location (encrypted)</label>
+                <label for="s-location" class="block text-sm font-medium text-slate-700 mb-1">Location (encrypted)</label>
                 <input id="s-location" type="text"
                   class="w-full px-4 py-2.5 rounded-xl border border-slate-200 focus:outline-none focus:ring-2 focus:ring-brand/40 text-sm" placeholder="e.g. Room 101 or Zoom link" />
               </div>
               <div class="mt-3">
-                <label class="block text-sm font-medium text-slate-700 mb-1">Description (encrypted)</label>
+                <label for="s-desc" class="block text-sm font-medium text-slate-700 mb-1">Description (encrypted)</label>
                 <textarea id="s-desc" rows="2"
                   class="w-full px-4 py-2.5 rounded-xl border border-slate-200 focus:outline-none focus:ring-2 focus:ring-brand/40 text-sm resize-none" placeholder="What will be covered in this session?"></textarea>
               </div>

--- a/public/teach.html
+++ b/public/teach.html
@@ -46,11 +46,14 @@
   <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
 
-      <!-- Create Activity -->
-      <section class="bg-white rounded-2xl shadow-sm border border-slate-100 overflow-hidden">
-        <div class="px-6 py-4 border-b border-slate-100 bg-gradient-to-r from-indigo-50 to-purple-50">
-          <h2 class="font-bold text-slate-800">&#127775; Create New Activity</h2>
-          <p class="text-slate-500 text-xs mt-0.5">Descriptions are encrypted at rest in D1.</p>
+      <!-- Create/Edit Activity -->
+      <section class="bg-white rounded-2xl shadow-sm border border-slate-100 overflow-hidden" id="act-section">
+        <div class="px-6 py-4 border-b border-slate-100 bg-gradient-to-r from-indigo-50 to-purple-50 flex justify-between items-center">
+          <div>
+            <h2 id="act-form-title" class="font-bold text-slate-800">&#127775; Create New Activity</h2>
+            <p class="text-slate-500 text-xs mt-0.5">Descriptions are encrypted at rest in D1.</p>
+          </div>
+          <button type="button" id="btn-cancel-act" onclick="cancelEditActivity()" class="hidden text-xs bg-slate-200 hover:bg-slate-300 text-slate-700 font-semibold py-1 px-3 rounded-lg">Cancel Edit</button>
         </div>
         <div class="p-6">
           <form id="form-activity" class="space-y-4" novalidate>
@@ -100,55 +103,69 @@
             </div>
             <p id="act-err" class="text-red-500 text-sm hidden"></p>
             <p id="act-ok" class="text-emerald-600 text-sm hidden"></p>
-            <button type="submit" class="w-full bg-brand text-white font-semibold py-2.5 rounded-xl hover:bg-brand-dark transition text-sm">Create Activity</button>
+            <button type="submit" id="btn-submit-act" class="w-full bg-brand text-white font-semibold py-2.5 rounded-xl hover:bg-brand-dark transition text-sm">Create Activity</button>
           </form>
         </div>
       </section>
 
-      <!-- Create Session -->
-      <section class="bg-white rounded-2xl shadow-sm border border-slate-100 overflow-hidden">
-        <div class="px-6 py-4 border-b border-slate-100 bg-gradient-to-r from-emerald-50 to-teal-50">
-          <h2 class="font-bold text-slate-800">&#128197; Add Session</h2>
-          <p class="text-slate-500 text-xs mt-0.5">Location and description are encrypted at rest.</p>
+      <!-- Add/Edit Session -->
+      <section class="bg-white rounded-2xl shadow-sm border border-slate-100 overflow-hidden" id="ses-section">
+        <div class="px-6 py-4 border-b border-slate-100 bg-gradient-to-r from-emerald-50 to-teal-50 flex justify-between items-center">
+          <div>
+            <h2 id="ses-form-title" class="font-bold text-slate-800">&#128197; Add Session</h2>
+            <p class="text-slate-500 text-xs mt-0.5">Location and description are encrypted at rest.</p>
+          </div>
+          <button type="button" id="btn-cancel-ses" onclick="cancelEditSession()" class="hidden text-xs bg-slate-200 hover:bg-slate-300 text-slate-700 font-semibold py-1 px-3 rounded-lg">Cancel Edit</button>
         </div>
         <div class="p-6">
           <form id="form-session" class="space-y-4" novalidate>
             <div>
               <label class="block text-sm font-medium text-slate-700 mb-1">Activity *</label>
-              <select id="s-activity" class="w-full px-3 py-2.5 rounded-xl border border-slate-200 focus:outline-none focus:ring-2 focus:ring-brand/40 text-sm">
+              <select id="s-activity" class="w-full px-3 py-2.5 rounded-xl border border-slate-200 focus:outline-none focus:ring-2 focus:ring-brand/40 text-sm" onchange="onActivitySelect()">
                 <option value="">Select one of your activities...</option>
               </select>
             </div>
-            <div>
-              <label class="block text-sm font-medium text-slate-700 mb-1">Session Title *</label>
-              <input id="s-title" type="text" required
-                class="w-full px-4 py-2.5 rounded-xl border border-slate-200 focus:outline-none focus:ring-2 focus:ring-brand/40 text-sm" placeholder="e.g. Week 1 - Introduction" />
+            
+            <div id="existing-sessions" class="hidden my-2">
+              <label class="block text-sm font-medium text-slate-700 mb-1">Existing Sessions</label>
+              <ul id="s-session-list" class="divide-y divide-slate-100 text-sm border border-slate-200 rounded-lg max-h-40 overflow-y-auto"></ul>
             </div>
-            <div class="grid grid-cols-2 gap-3">
+            
+            <div class="mt-4 border-t pt-4 border-slate-100" id="ses-fields">
               <div>
-                <label class="block text-sm font-medium text-slate-700 mb-1">Start Time</label>
-                <input id="s-start" type="datetime-local"
-                  class="w-full px-3 py-2.5 rounded-xl border border-slate-200 focus:outline-none focus:ring-2 focus:ring-brand/40 text-sm" />
+                <label id="ses-fields-title" class="block text-sm font-semibold text-slate-800 mb-2">New Session Details</label>
               </div>
               <div>
-                <label class="block text-sm font-medium text-slate-700 mb-1">End Time</label>
-                <input id="s-end" type="datetime-local"
-                  class="w-full px-3 py-2.5 rounded-xl border border-slate-200 focus:outline-none focus:ring-2 focus:ring-brand/40 text-sm" />
+                <label class="block text-sm font-medium text-slate-700 mb-1">Session Title *</label>
+                <input id="s-title" type="text" required
+                  class="w-full px-4 py-2.5 rounded-xl border border-slate-200 focus:outline-none focus:ring-2 focus:ring-brand/40 text-sm" placeholder="e.g. Week 1 - Introduction" />
               </div>
-            </div>
-            <div>
-              <label class="block text-sm font-medium text-slate-700 mb-1">Location (encrypted)</label>
-              <input id="s-location" type="text"
-                class="w-full px-4 py-2.5 rounded-xl border border-slate-200 focus:outline-none focus:ring-2 focus:ring-brand/40 text-sm" placeholder="e.g. Room 101 or Zoom link" />
-            </div>
-            <div>
-              <label class="block text-sm font-medium text-slate-700 mb-1">Description (encrypted)</label>
-              <textarea id="s-desc" rows="2"
-                class="w-full px-4 py-2.5 rounded-xl border border-slate-200 focus:outline-none focus:ring-2 focus:ring-brand/40 text-sm resize-none" placeholder="What will be covered in this session?"></textarea>
+              <div class="grid grid-cols-2 gap-3 mt-3">
+                <div>
+                  <label class="block text-sm font-medium text-slate-700 mb-1">Start Time</label>
+                  <input id="s-start" type="datetime-local"
+                    class="w-full px-3 py-2.5 rounded-xl border border-slate-200 focus:outline-none focus:ring-2 focus:ring-brand/40 text-sm" />
+                </div>
+                <div>
+                  <label class="block text-sm font-medium text-slate-700 mb-1">End Time</label>
+                  <input id="s-end" type="datetime-local"
+                    class="w-full px-3 py-2.5 rounded-xl border border-slate-200 focus:outline-none focus:ring-2 focus:ring-brand/40 text-sm" />
+                </div>
+              </div>
+              <div class="mt-3">
+                <label class="block text-sm font-medium text-slate-700 mb-1">Location (encrypted)</label>
+                <input id="s-location" type="text"
+                  class="w-full px-4 py-2.5 rounded-xl border border-slate-200 focus:outline-none focus:ring-2 focus:ring-brand/40 text-sm" placeholder="e.g. Room 101 or Zoom link" />
+              </div>
+              <div class="mt-3">
+                <label class="block text-sm font-medium text-slate-700 mb-1">Description (encrypted)</label>
+                <textarea id="s-desc" rows="2"
+                  class="w-full px-4 py-2.5 rounded-xl border border-slate-200 focus:outline-none focus:ring-2 focus:ring-brand/40 text-sm resize-none" placeholder="What will be covered in this session?"></textarea>
+              </div>
             </div>
             <p id="ses-err" class="text-red-500 text-sm hidden"></p>
             <p id="ses-ok" class="text-emerald-600 text-sm hidden"></p>
-            <button type="submit" class="w-full bg-emerald-600 text-white font-semibold py-2.5 rounded-xl hover:bg-emerald-700 transition text-sm">Add Session</button>
+            <button type="submit" id="btn-submit-ses" class="w-full bg-emerald-600 text-white font-semibold py-2.5 rounded-xl hover:bg-emerald-700 transition text-sm">Add Session</button>
           </form>
         </div>
       </section>
@@ -239,6 +256,7 @@
           '</div>' +
         '</div>' +
         '<div class="flex gap-2 shrink-0">' +
+          '<button onclick="startEditActivity(\'' + esc(a.id) + '\')" class="text-xs text-slate-600 font-semibold border border-slate-200 px-3 py-1.5 rounded-lg hover:bg-slate-50">Edit</button>' +
           '<a href="/course.html?id=' + esc(a.id) + '" class="text-xs text-brand font-semibold border border-brand/30 px-3 py-1.5 rounded-lg hover:bg-indigo-50">View</a>' +
         '</div>' +
       '</div>';
@@ -252,17 +270,61 @@
     setTimeout(() => el.classList.add('hidden'), 4000);
   }
 
+  let editActivityId = null;
+  let editSessionId = null;
+  let currentActivitySessions = [];
+
+  async function startEditActivity(id) {
+    const a = hostedActivities.find(act => act.id === id);
+    if (!a) return;
+    
+    // fetch details and get description
+    const res = await fetch('/api/activities/' + id, { headers: { Authorization: 'Bearer ' + token } });
+    const data = await res.json();
+    if (!res.ok) { showMsg('act-err', 'Failed to load activity details', true); return; }
+    
+    const fullAct = data.activity;
+    
+    document.getElementById('a-title').value = fullAct.title;
+    document.getElementById('a-desc').value = fullAct.description || '';
+    document.getElementById('a-type').value = fullAct.type;
+    document.getElementById('a-format').value = fullAct.format;
+    document.getElementById('a-schedule').value = fullAct.schedule_type;
+    document.getElementById('a-tags').value = (fullAct.tags || []).join(', ');
+    
+    document.getElementById('act-form-title').innerHTML = '&#9999;&#65039; Edit Activity';
+    document.getElementById('btn-submit-act').textContent = 'Update Activity';
+    document.getElementById('btn-cancel-act').classList.remove('hidden');
+    
+    editActivityId = id;
+    document.getElementById('act-section').scrollIntoView({ behavior: 'smooth' });
+  }
+
+  function cancelEditActivity() {
+    document.getElementById('form-activity').reset();
+    document.getElementById('act-form-title').innerHTML = '&#127775; Create New Activity';
+    document.getElementById('btn-submit-act').textContent = 'Create Activity';
+    document.getElementById('btn-cancel-act').classList.add('hidden');
+    editActivityId = null;
+  }
+
   document.getElementById('form-activity').addEventListener('submit', async e => {
     e.preventDefault();
     document.getElementById('act-err').classList.add('hidden');
     document.getElementById('act-ok').classList.add('hidden');
     const btn = e.target.querySelector('button[type=submit]');
-    btn.textContent = 'Creating...'; btn.disabled = true;
+    btn.textContent = editActivityId ? 'Updating...' : 'Creating...'; 
+    btn.disabled = true;
+    
     const rawTags = document.getElementById('a-tags').value;
     const tags = rawTags ? rawTags.split(',').map(t => t.trim()).filter(Boolean) : [];
+    
+    const method = editActivityId ? 'PUT' : 'POST';
+    const url = editActivityId ? `/api/activities/${editActivityId}` : '/api/activities';
+    
     try {
-      const res  = await fetch('/api/activities', {
-        method:'POST', headers:{ 'Content-Type':'application/json', Authorization:'Bearer ' + token },
+      const res  = await fetch(url, {
+        method, headers:{ 'Content-Type':'application/json', Authorization:'Bearer ' + token },
         body: JSON.stringify({
           title:         document.getElementById('a-title').value.trim(),
           description:   document.getElementById('a-desc').value.trim(),
@@ -274,25 +336,100 @@
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Failed');
-      showMsg('act-ok', 'Activity created: ' + data.data.title, false);
-      e.target.reset();
+      
+      showMsg('act-ok', `Activity ${editActivityId ? 'updated' : 'created'} successfully!`, false);
+      cancelEditActivity();
       await loadHostedActivities();
     } catch (err) { showMsg('act-err', err.message, true); }
-    finally { btn.textContent = 'Create Activity'; btn.disabled = false; }
+    finally { btn.disabled = false; btn.textContent = editActivityId ? 'Update Activity' : 'Create Activity'; }
   });
+
+  async function onActivitySelect() {
+    const actId = document.getElementById('s-activity').value;
+    const listDiv = document.getElementById('existing-sessions');
+    const ul = document.getElementById('s-session-list');
+    cancelEditSession();
+    
+    if (!actId) {
+      listDiv.classList.add('hidden');
+      return;
+    }
+
+    const res = await fetch('/api/activities/' + actId, { headers: { Authorization: 'Bearer ' + token } });
+    if (!res.ok) return;
+    const data = await res.json();
+    currentActivitySessions = data.sessions || [];
+    
+    if (currentActivitySessions.length === 0) {
+      listDiv.classList.add('hidden');
+    } else {
+      listDiv.classList.remove('hidden');
+      ul.innerHTML = currentActivitySessions.map(s => {
+        return `<li class="px-4 py-2 flex justify-between items-center bg-white hover:bg-slate-50">
+          <div>
+            <span class="font-semibold text-slate-800">${esc(s.title)}</span>
+            <div class="text-xs text-slate-500">${s.start_time || ''}</div>
+          </div>
+          <button type="button" onclick="startEditSession('${s.id}')" class="text-xs text-brand font-semibold border border-brand/30 px-2 py-1 rounded hover:bg-indigo-50">Edit</button>
+        </li>`;
+      }).join('');
+    }
+  }
+
+  function startEditSession(id) {
+    const s = currentActivitySessions.find(ses => ses.id === id);
+    if (!s) return;
+    
+    document.getElementById('s-title').value = s.title;
+    document.getElementById('s-desc').value = s.description || '';
+    
+    // browsers require YYYY-MM-DDThh:mm format for datetime-local
+    const fmt = v => v ? String(v).replace(' ', 'T') : '';
+    document.getElementById('s-start').value = fmt(s.start_time);
+    document.getElementById('s-end').value = fmt(s.end_time);
+    document.getElementById('s-location').value = s.location || '';
+    
+    document.getElementById('ses-form-title').innerHTML = '&#9999;&#65039; Edit Session';
+    document.getElementById('ses-fields-title').textContent = 'Editing Session Details';
+    document.getElementById('btn-submit-ses').textContent = 'Update Session';
+    document.getElementById('btn-cancel-ses').classList.remove('hidden');
+    
+    editSessionId = id;
+  }
+
+  function cancelEditSession() {
+    document.getElementById('s-title').value = '';
+    document.getElementById('s-desc').value = '';
+    document.getElementById('s-start').value = '';
+    document.getElementById('s-end').value = '';
+    document.getElementById('s-location').value = '';
+    
+    document.getElementById('ses-form-title').innerHTML = '&#128197; Add Session';
+    document.getElementById('ses-fields-title').textContent = 'New Session Details';
+    document.getElementById('btn-submit-ses').textContent = 'Add Session';
+    document.getElementById('btn-cancel-ses').classList.add('hidden');
+    editSessionId = null;
+  }
 
   document.getElementById('form-session').addEventListener('submit', async e => {
     e.preventDefault();
     document.getElementById('ses-err').classList.add('hidden');
     document.getElementById('ses-ok').classList.add('hidden');
-    const btn = e.target.querySelector('button[type=submit]');
+    
     const actId = document.getElementById('s-activity').value;
     if (!actId) { showMsg('ses-err', 'Please select an activity', true); return; }
-    btn.textContent = 'Adding...'; btn.disabled = true;
+    
+    const btn = e.target.querySelector('button[type=submit]');
+    btn.textContent = editSessionId ? 'Updating...' : 'Adding...'; 
+    btn.disabled = true;
+    
     const fmt = v => v ? v.replace('T',' ') : '';
+    const method = editSessionId ? 'PUT' : 'POST';
+    const url = editSessionId ? `/api/sessions/${editSessionId}` : '/api/sessions';
+
     try {
-      const res  = await fetch('/api/sessions', {
-        method:'POST', headers:{ 'Content-Type':'application/json', Authorization:'Bearer ' + token },
+      const res  = await fetch(url, {
+        method, headers:{ 'Content-Type':'application/json', Authorization:'Bearer ' + token },
         body: JSON.stringify({
           activity_id: actId,
           title:       document.getElementById('s-title').value.trim(),
@@ -304,15 +441,13 @@
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Failed');
-      showMsg('ses-ok', 'Session added successfully!', false);
-      document.getElementById('s-title').value    = '';
-      document.getElementById('s-desc').value     = '';
-      document.getElementById('s-start').value    = '';
-      document.getElementById('s-end').value      = '';
-      document.getElementById('s-location').value = '';
+      
+      showMsg('ses-ok', `Session ${editSessionId ? 'updated' : 'added'} successfully!`, false);
+      cancelEditSession();
+      await onActivitySelect(); // refresh session list
       await loadHostedActivities();
     } catch (err) { showMsg('ses-err', err.message, true); }
-    finally { btn.textContent = 'Add Session'; btn.disabled = false; }
+    finally { btn.textContent = editSessionId ? 'Update Session' : 'Add Session'; btn.disabled = false; }
   });
 </script>
 </body>

--- a/public/teach.html
+++ b/public/teach.html
@@ -356,7 +356,11 @@
     }
 
     const res = await fetch('/api/activities/' + actId, { headers: { Authorization: 'Bearer ' + token } });
-    if (!res.ok) return;
+    if (!res.ok) {
+      showMsg('ses-err', 'Failed to load sessions for this activity', true);
+      listDiv.classList.add('hidden');
+      return;
+    }
     const data = await res.json();
     currentActivitySessions = data.sessions || [];
     
@@ -370,7 +374,7 @@
             <span class="font-semibold text-slate-800">${esc(s.title)}</span>
             <div class="text-xs text-slate-500">${s.start_time || ''}</div>
           </div>
-          <button type="button" onclick="startEditSession('${s.id}')" class="text-xs text-brand font-semibold border border-brand/30 px-2 py-1 rounded hover:bg-indigo-50">Edit</button>
+          <button type="button" onclick="startEditSession('${esc(s.id)}')" class="text-xs text-brand font-semibold border border-brand/30 px-2 py-1 rounded hover:bg-indigo-50">Edit</button>
         </li>`;
       }).join('');
     }

--- a/public/teach.html
+++ b/public/teach.html
@@ -454,8 +454,9 @@
       
       showMsg('ses-ok', `Session ${editSessionId ? 'updated' : 'added'} successfully!`, false);
       cancelEditSession();
-      await onActivitySelect(); // refresh session list
       await loadHostedActivities();
+      document.getElementById('s-activity').value = actId;
+      await onActivitySelect(); // refresh session list
     } catch (err) { showMsg('ses-err', err.message, true); }
     finally { btn.textContent = editSessionId ? 'Update Session' : 'Add Session'; btn.disabled = false; }
   });

--- a/public/teach.html
+++ b/public/teach.html
@@ -127,13 +127,13 @@
             </div>
             
             <div id="existing-sessions" class="hidden my-2">
-              <label class="block text-sm font-medium text-slate-700 mb-1">Existing Sessions</label>
+              <h3 class="block text-sm font-medium text-slate-700 mb-1">Existing Sessions</h3>
               <ul id="s-session-list" class="divide-y divide-slate-100 text-sm border border-slate-200 rounded-lg max-h-40 overflow-y-auto"></ul>
             </div>
             
             <div class="mt-4 border-t pt-4 border-slate-100" id="ses-fields">
               <div>
-                <label id="ses-fields-title" class="block text-sm font-semibold text-slate-800 mb-2">New Session Details</label>
+                <h3 id="ses-fields-title" class="block text-sm font-semibold text-slate-800 mb-2">New Session Details</h3>
               </div>
               <div>
                 <label for="s-title" class="block text-sm font-medium text-slate-700 mb-1">Session Title *</label>
@@ -273,14 +273,18 @@
   let editActivityId = null;
   let editSessionId = null;
   let currentActivitySessions = [];
+  let activityEditLoadSeq = 0;
+  let sessionListLoadSeq = 0;
 
   async function startEditActivity(id) {
+    const loadSeq = ++activityEditLoadSeq;
     const a = hostedActivities.find(act => act.id === id);
     if (!a) return;
     
     // fetch details and get description
     const res = await fetch('/api/activities/' + id, { headers: { Authorization: 'Bearer ' + token } });
     const data = await res.json();
+    if (loadSeq !== activityEditLoadSeq) return;
     if (!res.ok) { showMsg('act-err', 'Failed to load activity details', true); return; }
     
     const fullAct = data.activity;
@@ -346,6 +350,7 @@
 
   async function onActivitySelect() {
     const actId = document.getElementById('s-activity').value;
+    const loadSeq = ++sessionListLoadSeq;
     const listDiv = document.getElementById('existing-sessions');
     const ul = document.getElementById('s-session-list');
     cancelEditSession();
@@ -362,6 +367,7 @@
       return;
     }
     const data = await res.json();
+    if (loadSeq !== sessionListLoadSeq || document.getElementById('s-activity').value !== actId) return;
     currentActivitySessions = data.sessions || [];
     
     if (currentActivitySessions.length === 0) {

--- a/src/worker.py
+++ b/src/worker.py
@@ -1128,7 +1128,7 @@ async def api_update_activity(act_id, req, env):
         except Exception as e:
             capture_exception(e, req, env, "api_update_activity.update_activity")
             return err("Failed to update activity, please try again", 500)
-    else:
+    elif "tags" not in body:
         return ok(None, "No changes provided")
 
     if "tags" in body:

--- a/src/worker.py
+++ b/src/worker.py
@@ -1108,7 +1108,7 @@ async def api_update_activity(act_id, req, env):
             return err("type must be a string", 400)
         atype = atype.strip()
         if atype not in ("course", "meetup", "workshop", "seminar", "other"):
-            atype = "course"
+            return err("type must be one of: course, meetup, workshop, seminar, other", 400)
         updates.append("type=(?)")
         params.append(atype)
 
@@ -1117,7 +1117,7 @@ async def api_update_activity(act_id, req, env):
             return err("format must be a string", 400)
         fmt = fmt.strip()
         if fmt not in ("live", "self_paced", "hybrid"):
-            fmt = "self_paced"
+            return err("format must be one of: live, self_paced, hybrid", 400)
         updates.append("format=(?)")
         params.append(fmt)
 
@@ -1126,7 +1126,7 @@ async def api_update_activity(act_id, req, env):
             return err("schedule_type must be a string", 400)
         schedule_type = schedule_type.strip()
         if schedule_type not in ("one_time", "multi_session", "recurring", "ongoing"):
-            schedule_type = "ongoing"
+            return err("schedule_type must be one of: one_time, multi_session, recurring, ongoing", 400)
         updates.append("schedule_type=(?)")
         params.append(schedule_type)
 
@@ -1142,7 +1142,7 @@ async def api_update_activity(act_id, req, env):
         return ok(None, "No changes provided")
 
     if "tags" in body:
-        tags = body.get("tags") or []
+        tags = body.get("tags")
         try:
             await env.DB.prepare("DELETE FROM activity_tags WHERE activity_id=?").bind(act_id).run()
         except Exception as e:

--- a/src/worker.py
+++ b/src/worker.py
@@ -1062,6 +1062,167 @@ async def api_add_activity_tags(req, env):
     return ok(None, "Tags updated")
 
 
+async def api_update_activity(act_id, req, env):
+    user = verify_token(req.headers.get("Authorization"), env.JWT_SECRET)
+    if not user:
+        return err("Authentication required", 401)
+
+    body, bad_resp = await parse_json_object(req)
+    if bad_resp:
+        return bad_resp
+
+    title         = body.get("title")
+    description   = body.get("description")
+    atype         = body.get("type")
+    fmt           = body.get("format")
+    schedule_type = body.get("schedule_type")
+
+    owned = await env.DB.prepare(
+        "SELECT id FROM activities WHERE id=? AND host_id=?"
+    ).bind(act_id, user["id"]).first()
+    if not owned:
+        return err("Activity not found or access denied", 404)
+
+    updates = []
+    params = []
+
+    if title is not None:
+        title = title.strip()
+        if not title:
+            return err("title cannot be empty")
+        updates.append("title=(?)")
+        params.append(title)
+
+    if description is not None:
+        description = description.strip()
+        enc = env.ENCRYPTION_KEY
+        updates.append("description=(?)")
+        params.append(encrypt(description, enc) if description else "")
+
+    if atype is not None:
+        atype = atype.strip()
+        if atype not in ("course", "meetup", "workshop", "seminar", "other"):
+            atype = "course"
+        updates.append("type=(?)")
+        params.append(atype)
+
+    if fmt is not None:
+        fmt = fmt.strip()
+        if fmt not in ("live", "self_paced", "hybrid"):
+            fmt = "self_paced"
+        updates.append("format=(?)")
+        params.append(fmt)
+
+    if schedule_type is not None:
+        schedule_type = schedule_type.strip()
+        if schedule_type not in ("one_time", "multi_session", "recurring", "ongoing"):
+            schedule_type = "ongoing"
+        updates.append("schedule_type=(?)")
+        params.append(schedule_type)
+
+    if updates:
+        params.append(act_id)
+        query = "UPDATE activities SET " + ", ".join(updates) + " WHERE id=(?)"
+        try:
+            await env.DB.prepare(query).bind(*params).run()
+        except Exception as e:
+            capture_exception(e, req, env, "api_update_activity.update_activity")
+            return err("Failed to update activity, please try again", 500)
+
+    if "tags" in body:
+        tags = body.get("tags") or []
+        try:
+            await env.DB.prepare("DELETE FROM activity_tags WHERE activity_id=?").bind(act_id).run()
+        except Exception:
+            pass
+
+        for tag_name in tags:
+            tag_name = tag_name.strip()
+            if not tag_name:
+                continue
+            t_row = await env.DB.prepare("SELECT id FROM tags WHERE name=?").bind(tag_name).first()
+            if t_row:
+                tag_id = t_row.id
+            else:
+                tag_id = new_id()
+                try:
+                    await env.DB.prepare("INSERT INTO tags (id,name) VALUES (?,?)").bind(tag_id, tag_name).run()
+                except Exception:
+                    continue
+            try:
+                await env.DB.prepare("INSERT OR IGNORE INTO activity_tags (activity_id,tag_id) VALUES (?,?)").bind(act_id, tag_id).run()
+            except Exception:
+                pass
+
+    return ok(None, "Activity updated")
+
+
+async def api_update_session(ses_id, req, env):
+    user = verify_token(req.headers.get("Authorization"), env.JWT_SECRET)
+    if not user:
+        return err("Authentication required", 401)
+
+    body, bad_resp = await parse_json_object(req)
+    if bad_resp:
+        return bad_resp
+
+    row = await env.DB.prepare(
+        "SELECT s.activity_id, a.host_id FROM sessions s JOIN activities a ON s.activity_id = a.id WHERE s.id=?"
+    ).bind(ses_id).first()
+
+    if not row or row.host_id != user["id"]:
+        return err("Session not found or access denied", 404)
+
+    title       = body.get("title")
+    description = body.get("description")
+    start_time  = body.get("start_time")
+    end_time    = body.get("end_time")
+    location    = body.get("location")
+
+    updates = []
+    params = []
+
+    if title is not None:
+        title = title.strip()
+        if not title:
+            return err("title cannot be empty")
+        updates.append("title=(?)")
+        params.append(title)
+
+    if description is not None:
+        description = description.strip()
+        enc = env.ENCRYPTION_KEY
+        updates.append("description=(?)")
+        params.append(encrypt(description, enc) if description else "")
+
+    if start_time is not None:
+        start_time = start_time.strip()
+        updates.append("start_time=(?)")
+        params.append(start_time)
+
+    if end_time is not None:
+        end_time = end_time.strip()
+        updates.append("end_time=(?)")
+        params.append(end_time)
+
+    if location is not None:
+        location = location.strip()
+        enc = env.ENCRYPTION_KEY
+        updates.append("location=(?)")
+        params.append(encrypt(location, enc) if location else "")
+
+    if updates:
+        params.append(ses_id)
+        query = "UPDATE sessions SET " + ", ".join(updates) + " WHERE id=(?)"
+        try:
+            await env.DB.prepare(query).bind(*params).run()
+        except Exception as e:
+            capture_exception(e, req, env, "api_update_session.update_session")
+            return err("Failed to update session, please try again", 500)
+
+    return ok(None, "Session updated")
+
+
 async def api_admin_table_counts(req, env):
     if not _is_basic_auth_valid(req, env):
         return _unauthorized_basic()
@@ -1179,6 +1340,8 @@ async def _dispatch(request, env):
         m = re.fullmatch(r"/api/activities/([A-Za-z0-9_-]+)", path)
         if m and method == "GET":
             return await api_get_activity(m.group(1), request, env)
+        if m and method == "PUT":
+            return await api_update_activity(m.group(1), request, env)
 
         if path == "/api/join" and method == "POST":
             return await api_join(request, env)
@@ -1188,6 +1351,10 @@ async def _dispatch(request, env):
 
         if path == "/api/sessions" and method == "POST":
             return await api_create_session(request, env)
+            
+        m_ses = re.fullmatch(r"/api/sessions/([A-Za-z0-9_-]+)", path)
+        if m_ses and method == "PUT":
+            return await api_update_session(m_ses.group(1), request, env)
 
         if path == "/api/tags" and method == "GET":
             return await api_list_tags(request, env)

--- a/src/worker.py
+++ b/src/worker.py
@@ -1128,31 +1128,34 @@ async def api_update_activity(act_id, req, env):
         except Exception as e:
             capture_exception(e, req, env, "api_update_activity.update_activity")
             return err("Failed to update activity, please try again", 500)
+    else:
+        return ok(None, "No changes provided")
 
     if "tags" in body:
         tags = body.get("tags") or []
         try:
             await env.DB.prepare("DELETE FROM activity_tags WHERE activity_id=?").bind(act_id).run()
-        except Exception:
-            pass
+        except Exception as e:
+            capture_exception(e, req, env, "api_update_activity.delete_activity_tags")
 
         for tag_name in tags:
-            tag_name = tag_name.strip()
-            if not tag_name:
+            tag_name_clean = tag_name.strip()
+            if not tag_name_clean:
                 continue
-            t_row = await env.DB.prepare("SELECT id FROM tags WHERE name=?").bind(tag_name).first()
+            t_row = await env.DB.prepare("SELECT id FROM tags WHERE name=?").bind(tag_name_clean).first()
             if t_row:
                 tag_id = t_row.id
             else:
                 tag_id = new_id()
                 try:
-                    await env.DB.prepare("INSERT INTO tags (id,name) VALUES (?,?)").bind(tag_id, tag_name).run()
-                except Exception:
+                    await env.DB.prepare("INSERT INTO tags (id,name) VALUES (?,?)").bind(tag_id, tag_name_clean).run()
+                except Exception as e:
+                    capture_exception(e, req, env, f"api_update_activity.insert_tag: tag_name={tag_name_clean}")
                     continue
             try:
                 await env.DB.prepare("INSERT OR IGNORE INTO activity_tags (activity_id,tag_id) VALUES (?,?)").bind(act_id, tag_id).run()
-            except Exception:
-                pass
+            except Exception as e:
+                capture_exception(e, req, env, f"api_update_activity.insert_activity_tag: tag_id={tag_id}")
 
     return ok(None, "Activity updated")
 
@@ -1219,6 +1222,8 @@ async def api_update_session(ses_id, req, env):
         except Exception as e:
             capture_exception(e, req, env, "api_update_session.update_session")
             return err("Failed to update session, please try again", 500)
+    else:
+        return ok(None, "No changes provided")
 
     return ok(None, "Session updated")
 

--- a/src/worker.py
+++ b/src/worker.py
@@ -1143,6 +1143,10 @@ async def api_update_activity(act_id, req, env):
 
     if "tags" in body:
         tags = body.get("tags")
+        if tags is None:
+            tags = []
+        if not isinstance(tags, list) or any(not isinstance(tag, str) for tag in tags):
+            return err("tags must be an array of strings", 400)
         try:
             await env.DB.prepare("DELETE FROM activity_tags WHERE activity_id=?").bind(act_id).run()
         except Exception as e:

--- a/src/worker.py
+++ b/src/worker.py
@@ -1087,6 +1087,8 @@ async def api_update_activity(act_id, req, env):
     params = []
 
     if title is not None:
+        if not isinstance(title, str):
+            return err("title must be a string", 400)
         title = title.strip()
         if not title:
             return err("title cannot be empty")
@@ -1094,12 +1096,16 @@ async def api_update_activity(act_id, req, env):
         params.append(title)
 
     if description is not None:
+        if not isinstance(description, str):
+            return err("description must be a string", 400)
         description = description.strip()
         enc = env.ENCRYPTION_KEY
         updates.append("description=(?)")
         params.append(encrypt(description, enc) if description else "")
 
     if atype is not None:
+        if not isinstance(atype, str):
+            return err("type must be a string", 400)
         atype = atype.strip()
         if atype not in ("course", "meetup", "workshop", "seminar", "other"):
             atype = "course"
@@ -1107,6 +1113,8 @@ async def api_update_activity(act_id, req, env):
         params.append(atype)
 
     if fmt is not None:
+        if not isinstance(fmt, str):
+            return err("format must be a string", 400)
         fmt = fmt.strip()
         if fmt not in ("live", "self_paced", "hybrid"):
             fmt = "self_paced"
@@ -1114,6 +1122,8 @@ async def api_update_activity(act_id, req, env):
         params.append(fmt)
 
     if schedule_type is not None:
+        if not isinstance(schedule_type, str):
+            return err("schedule_type must be a string", 400)
         schedule_type = schedule_type.strip()
         if schedule_type not in ("one_time", "multi_session", "recurring", "ongoing"):
             schedule_type = "ongoing"
@@ -1139,6 +1149,8 @@ async def api_update_activity(act_id, req, env):
             capture_exception(e, req, env, "api_update_activity.delete_activity_tags")
 
         for tag_name in tags:
+            if not isinstance(tag_name, str):
+                continue
             tag_name_clean = tag_name.strip()
             if not tag_name_clean:
                 continue
@@ -1186,6 +1198,8 @@ async def api_update_session(ses_id, req, env):
     params = []
 
     if title is not None:
+        if not isinstance(title, str):
+            return err("title must be a string", 400)
         title = title.strip()
         if not title:
             return err("title cannot be empty")
@@ -1193,22 +1207,30 @@ async def api_update_session(ses_id, req, env):
         params.append(title)
 
     if description is not None:
+        if not isinstance(description, str):
+            return err("description must be a string", 400)
         description = description.strip()
         enc = env.ENCRYPTION_KEY
         updates.append("description=(?)")
         params.append(encrypt(description, enc) if description else "")
 
     if start_time is not None:
+        if not isinstance(start_time, str):
+            return err("start_time must be a string", 400)
         start_time = start_time.strip()
         updates.append("start_time=(?)")
         params.append(start_time)
 
     if end_time is not None:
+        if not isinstance(end_time, str):
+            return err("end_time must be a string", 400)
         end_time = end_time.strip()
         updates.append("end_time=(?)")
         params.append(end_time)
 
     if location is not None:
+        if not isinstance(location, str):
+            return err("location must be a string", 400)
         location = location.strip()
         enc = env.ENCRYPTION_KEY
         updates.append("location=(?)")
@@ -1226,7 +1248,6 @@ async def api_update_session(ses_id, req, env):
         return ok(None, "No changes provided")
 
     return ok(None, "Session updated")
-
 
 async def api_admin_table_counts(req, env):
     if not _is_basic_auth_valid(req, env):


### PR DESCRIPTION
## The goal of this PR is to allow activities and sessions to be editable after creation. Currently, the user can create them but not update them. 
Added Endpoints: PUT `/api/activities/:id` and PUT `/api/sessions/:id` routes in the backend.
Added functions: `api_update_activity()`, `api_update_session()`
Updated Frontend: `teach.html`

## After results:
<p align='center'>
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/7b2d7439-79cc-4e63-a781-653177bf652c" />
</p>

## Do watch the ScreenRecording & see the implementation in action:

https://github.com/user-attachments/assets/b0255264-9ead-474e-b882-59323d067759




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Overview
Adds in-place edit/update support for activities and sessions. Backend: new PUT APIs and routing for updating activities and sessions with ownership checks. Frontend: teach.html updated to support start/cancel edit flows and switch forms between create/add and update modes.

Key changes

Backend (src/worker.py)
- New endpoints and dispatch routing:
  - PUT /api/activities/:id → api_update_activity(act_id, req, env)
  - PUT /api/sessions/:id → api_update_session(ses_id, req, env)
- Authentication and ownership enforced (401 for missing/invalid token, 404 when resource not found or access denied).
- JSON parsing and validation of allowed fields; returns 200 "No changes provided" when nothing to update.
- Activity update behavior:
  - Conditionally updates provided fields (title, description, type, format, schedule_type) with trimming/validation and encryption where applicable.
  - Optional tags replacement: deletes existing activity_tags, ensures tag rows exist (insert if missing), and inserts junction rows (INSERT OR IGNORE). Tag-sync errors are logged/captured but do not abort the update.
- Session update behavior:
  - Verifies host ownership via sessions→activities join; conditionally updates fields (title, description, start_time, end_time, location) with validation/encryption and returns 200 on success.

Frontend (public/teach.html)
- Activity form:
  - Converted to combined create/edit UI with stable IDs (act-section, act-form-title, btn-submit-act, btn-cancel-act).
  - editActivityId state and functions: startEditActivity(id) fetches full activity, populates fields (including tags), switches UI to edit mode; cancelEditActivity() resets form.
  - Submit handler branches: POST /api/activities for create vs PUT /api/activities/:id for update; button text and messages reflect mode.
  - Hosted activities list now includes an Edit button that triggers startEditActivity.
- Session form:
  - Converted to add/edit workflow with stable IDs (ses-section, ses-form-title, ses-fields-title, existing-sessions, s-session-list, btn-submit-ses, btn-cancel-ses).
  - onActivitySelect() fetches selected activity’s sessions, stores in currentActivitySessions, renders per-session Edit buttons, and hides list if empty; sequence counters guard against stale responses.
  - startEditSession(id)/cancelEditSession() populate/reset session inputs (formats datetime-local) and toggle add/update mode.
  - Submit handler branches: POST /api/sessions for add vs PUT /api/sessions/:id for update; on success hosted activities and session list are refreshed and edit state cleared.

Impact
- UX: users can edit activities and sessions inline with clear mode switching and cancellation.
- Security/consistency: backend enforces ownership; activity tag replacement is destructive-by-design (delete + reinsert) and tag-sync failures are non-fatal but logged—reviewers should consider transactional/tag error handling if stronger guarantees are required.
- Review effort: high — changes touch auth/DB update logic, tag synchronization, encryption of fields, and substantial frontend state/flow updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->