### PR TITLE
fix: harden security — configurable CORS origin, role escalation, unauthenticated seed

### DIFF
--- a/src/worker.py
+++ b/src/worker.py
@@ -193,8 +193,8 @@ def verify_token(raw: str, secret: str):
 # Response helpers
 # ---------------------------------------------------------------------------
 
+_CORS_ORIGIN_INITIALISED = False
 _CORS = {
-    "Access-Control-Allow-Origin":  "*",
     "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type, Authorization",
 }
@@ -870,12 +870,11 @@ async def api_join(req, env):
         return bad_resp
 
     act_id = body.get("activity_id")
-    role   = (body.get("role") or "participant").strip()
 
     if not act_id:
         return err("activity_id is required")
-    if role not in ("participant", "instructor", "organizer"):
-        role = "participant"
+
+    role = "participant"
 
     act = await env.DB.prepare(
         "SELECT id FROM activities WHERE id=?"
@@ -1134,6 +1133,12 @@ async def serve_static(path: str, env):
 # ---------------------------------------------------------------------------
 
 async def _dispatch(request, env):
+    global _CORS_ORIGIN_INITIALISED
+    if not _CORS_ORIGIN_INITIALISED:
+        _CORS_ORIGIN_INITIALISED = True
+        origin = getattr(env, "ALLOWED_ORIGIN", "")
+        _CORS["Access-Control-Allow-Origin"] = origin if origin else "*"
+
     path   = urlparse(request.url).path
     method = request.method.upper()
     admin_path = _clean_path(getattr(env, "ADMIN_URL", ""))
@@ -1156,6 +1161,8 @@ async def _dispatch(request, env):
                 return err("Database init failed — check D1 binding", 500)
 
         if path == "/api/seed" and method == "POST":
+            if not _is_basic_auth_valid(request, env):
+                return _unauthorized_basic()
             try:
                 await init_db(env)
                 await seed_db(env, env.ENCRYPTION_KEY)

--- a/src/worker.py
+++ b/src/worker.py
@@ -1136,7 +1136,7 @@ async def _dispatch(request, env):
     global _CORS_ORIGIN_INITIALISED
     if not _CORS_ORIGIN_INITIALISED:
         _CORS_ORIGIN_INITIALISED = True
-        origin = getattr(env, "ALLOWED_ORIGIN", "")
+        origin = (getattr(env, "ALLOWED_ORIGIN", "") or "").strip()
         _CORS["Access-Control-Allow-Origin"] = origin if origin else "*"
 
     path   = urlparse(request.url).path


### PR DESCRIPTION
## What

Three security fixes in `src/worker.py`:

1. **Configurable CORS origin** — `Access-Control-Allow-Origin` was hardcoded to `*`, allowing any website to read authenticated API responses (e.g. user dashboard data). The origin is now loaded from the `ALLOWED_ORIGIN` env var at runtime. When the variable is not set, the wildcard is preserved as a fallback so existing deployments are not disrupted.

2. **Self-assigned privileged roles** — `POST /api/join` accepted a user-supplied `role` field, allowing any authenticated user to enroll as `instructor` or `organizer`. The role is now hardcoded to `participant`.

3. **Unauthenticated `/api/seed`** — Anyone could `POST /api/seed` without credentials and overwrite the database with sample data. The endpoint now requires the same HTTP Basic Auth used by the admin panel (`ADMIN_BASIC_USER` / `ADMIN_BASIC_PASS`). `/api/init` remains open because it only runs idempotent `CREATE TABLE IF NOT EXISTS` statements and is needed to bootstrap a fresh deployment before admin credentials exist.

## Reproduction

All three issues were reproduced locally against `wrangler dev` on `localhost:8787`.

**CORS origin:**
```
curl -sI -X OPTIONS http://localhost:8787/api/activities -H "Origin: https://evil.com"
# Before: Access-Control-Allow-Origin: * (always)
# After:  Access-Control-Allow-Origin: <ALLOWED_ORIGIN value> (or * if not configured)
```

**Role escalation:**
```
# Register, then join as instructor
curl -s -X POST http://localhost:8787/api/join \
  -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" \
  -d '{"activity_id":"act-py-begin","role":"instructor"}'
# Before: dashboard shows Role: instructor
# After:  dashboard shows Role: participant
```

**Unauthenticated seed:**
```
curl -s -X POST http://localhost:8787/api/seed
# Before: {"success": true, "message": "Sample data seeded"}
# After:  401 Authentication required
```

## Configuration

After this change, set `ALLOWED_ORIGIN` for cross-origin access:

- Local dev: add `ALLOWED_ORIGIN=http://localhost:8787` to `.dev.vars`
- Production: `wrangler secret put ALLOWED_ORIGIN`

Same-origin requests (frontend served by the same worker) do not need CORS headers and work without this variable. When `ALLOWED_ORIGIN` is not configured, the wildcard `*` is used as a fallback to avoid breaking existing deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Security Hardening: Configurable CORS, Prevent Role Escalation, and Authenticated Seeding

This PR applies three targeted security fixes in src/worker.py to reduce attack surface and tighten access control.

- Configurable CORS origin
  - Moves Access-Control-Allow-Origin out of the shared CORS template and initializes it once per worker isolate from ALLOWED_ORIGIN (trimmed). A per-isolate guard (_CORS_ORIGIN_INITIALISED) ensures one-time setup. Falls back to "*" when ALLOWED_ORIGIN is unset.
  - Documentation added for setting ALLOWED_ORIGIN in local (.dev.vars) and production (wrangler secret) environments.
  - Backward compatibility: fallback preserves prior "*" behavior when ALLOWED_ORIGIN is not set.

- Prevent role escalation
  - POST /api/join ignores any client-supplied role; the enrolled role is unconditionally set to "participant" before insert/upsert, preventing authenticated users from self-assigning privileged roles (e.g., instructor, organizer).

- Require auth for seeding
  - POST /api/seed now requires HTTP Basic Auth validated against ADMIN_BASIC_USER / ADMIN_BASIC_PASS; invalid or missing credentials return an unauthorized response. The change enforces that seeding cannot be triggered anonymously.
  - POST /api/init remains unauthenticated to allow idempotent DB bootstrapping (CREATE TABLE IF NOT EXISTS) before admin credentials exist.

Other notes
- ALLOWED_ORIGIN is trimmed using the existing getattr(... or "").strip() pattern consistent with how admin creds are handled.
- The changes are minimal and backward compatible for deployments that don't set ALLOWED_ORIGIN or admin credentials, but workflows relying on unauthenticated seeding or client-supplied roles must be updated.

Impact: strengthens authorization and access controls with small behavioral changes that prevent CORS misconfiguration, role escalation, and unauthenticated data seeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->