### PR TITLE
fix: Resolve Web Crypto AES-GCM Map conversion bug during encryption

### DIFF
--- a/src/worker.py
+++ b/src/worker.py
@@ -166,7 +166,8 @@ async def decrypt_aes(ciphertext: str, secret: str) -> str:
     try:
         key_bytes  = _derive_aes_key_bytes(secret)
         crypto_key = await _import_aes_key(key_bytes)
-        algo       = to_js({"name": "AES-GCM", "iv": to_js(iv)}, dict_converter=js.Object.fromEntries)
+        iv_array   = to_js(iv)
+        algo       = to_js({"name": "AES-GCM", "iv": iv_array}, dict_converter=js.Object.fromEntries)
         data       = to_js(ct)
         pt_buf     = await js.crypto.subtle.decrypt(algo, crypto_key, data)
         return bytes(js.Uint8Array.new(pt_buf)).decode("utf-8")

--- a/src/worker.py
+++ b/src/worker.py
@@ -43,6 +43,8 @@ from urllib.parse import urlparse, parse_qs
 
 from workers import Response
 
+import js
+from pyodide.ffi import to_js
 
 def capture_exception(exc: Exception, req=None, _env=None, where: str = ""):
     """Best-effort exception logging with full traceback and request context."""
@@ -109,8 +111,6 @@ def _derive_aes_key_bytes(secret: str) -> bytes:
 
 async def _import_aes_key(key_bytes: bytes) -> object:
     """Import raw bytes as a Web Crypto AES-GCM CryptoKey."""
-    import js
-    from pyodide.ffi import to_js
     key_buf = to_js(key_bytes, create_pyproxies=False)
     algo    = to_js({"name": "AES-GCM"}, dict_converter=js.Object.fromEntries)
     usages  = to_js(["encrypt", "decrypt"])
@@ -126,8 +126,6 @@ async def encrypt_aes(plaintext: str, secret: str) -> str:
     if not plaintext:
         return ""
     try:
-        import js
-        from pyodide.ffi import to_js
         key_bytes  = _derive_aes_key_bytes(secret)
         crypto_key = await _import_aes_key(key_bytes)
 
@@ -155,8 +153,6 @@ async def decrypt_aes(ciphertext: str, secret: str) -> str:
         return ""
     if not ciphertext.startswith("v1:"):
         return _decrypt_xor(ciphertext, secret)
-    import js
-    from pyodide.ffi import to_js
     try:
         raw        = base64.b64decode(ciphertext[3:])
         iv, ct     = raw[:12], raw[12:]

--- a/src/worker.py
+++ b/src/worker.py
@@ -112,8 +112,8 @@ async def _import_aes_key(key_bytes: bytes) -> object:
     import js
     from pyodide.ffi import to_js
     key_buf = to_js(key_bytes, create_pyproxies=False)
-    algo    = to_js({"name": "AES-GCM"}, create_pyproxies=False)
-    usages  = to_js(["encrypt", "decrypt"], create_pyproxies=False)
+    algo    = to_js({"name": "AES-GCM"}, dict_converter=js.Object.fromEntries)
+    usages  = to_js(["encrypt", "decrypt"])
     return await js.crypto.subtle.importKey("raw", key_buf, algo, False, usages)
 
 
@@ -130,9 +130,15 @@ async def encrypt_aes(plaintext: str, secret: str) -> str:
         from pyodide.ffi import to_js
         key_bytes  = _derive_aes_key_bytes(secret)
         crypto_key = await _import_aes_key(key_bytes)
-        iv         = bytes(js.crypto.getRandomValues(to_js(bytearray(12))))
-        algo       = to_js({"name": "AES-GCM", "iv": to_js(iv)}, create_pyproxies=False)
-        data       = to_js(plaintext.encode("utf-8"), create_pyproxies=False)
+
+        # Generate random IV directly into a JS Uint8Array for clean interop
+        iv_array   = js.Uint8Array.new(12)
+        js.crypto.getRandomValues(iv_array)
+        iv         = bytes(iv_array) # Extract back to python bytes for storage
+
+        # Using dict_converter ensures Web Crypto does not see "undefined" for the algo name
+        algo       = to_js({"name": "AES-GCM", "iv": iv_array}, dict_converter=js.Object.fromEntries)
+        data       = to_js(plaintext.encode("utf-8"))
         ct_buf     = await js.crypto.subtle.encrypt(algo, crypto_key, data)
         ct         = bytes(js.Uint8Array.new(ct_buf))
         return "v1:" + base64.b64encode(iv + ct).decode("ascii")
@@ -157,12 +163,12 @@ async def decrypt_aes(ciphertext: str, secret: str) -> str:
     except Exception as exc:
         capture_exception(exc, where="decrypt_aes.decode")
         return "[decryption error]"
-    key_bytes  = _derive_aes_key_bytes(secret)
-    crypto_key = await _import_aes_key(key_bytes)
-    algo       = to_js({"name": "AES-GCM", "iv": to_js(iv)}, create_pyproxies=False)
-    data       = to_js(ct, create_pyproxies=False)
     try:
-        pt_buf = await js.crypto.subtle.decrypt(algo, crypto_key, data)
+        key_bytes  = _derive_aes_key_bytes(secret)
+        crypto_key = await _import_aes_key(key_bytes)
+        algo       = to_js({"name": "AES-GCM", "iv": to_js(iv)}, dict_converter=js.Object.fromEntries)
+        data       = to_js(ct)
+        pt_buf     = await js.crypto.subtle.decrypt(algo, crypto_key, data)
         return bytes(js.Uint8Array.new(pt_buf)).decode("utf-8")
     except Exception as exc:
         # Auth tag mismatch = tampered/corrupted ciphertext


### PR DESCRIPTION
## This PR resolves registration failures `(NotSupportedError: Unrecognized key import algorithm "undefined" requested.)`, occurred while registering a new user. 

### By Explicitly converting Python dictionaries to standard JavaScript Objects using `dict_converter=js.Object.fromEntries` when passing cryptographic algorithm parameters to `js.crypto.subtle`, preventing Pyodide from mistakenly converting them into Map objects.

<img width="1652" height="874" alt="image" src="https://github.com/user-attachments/assets/908d0284-1cd3-46cd-803d-7c0ad9592287" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a Pyodide ↔ Web Crypto AES-GCM interop bug that caused registration failures with `NotSupportedError: Unrecognized key import algorithm "undefined"`. Pyodide was marshaling Python dicts as JS Maps, which resulted in an undefined algorithm being passed to the Web Crypto API. The change ensures algorithm parameters are converted to plain JS Objects so AES-256-GCM key import/encryption works correctly.

## Key changes (src/worker.py)

- _import_aes_key
  - Build the algorithm parameter as a plain JS Object using `dict_converter=js.Object.fromEntries` when calling `to_js`, preventing Map conversion.
  - Remove reliance on previously used `create_pyproxies=False` for algorithm marshaling.

- encrypt_aes
  - Allocate IV as a native JS `Uint8Array(12)` and fill it with `js.crypto.getRandomValues`.
  - Convert the IV back to Python bytes for storage.
  - Marshal the algorithm with `dict_converter=js.Object.fromEntries` (e.g., `{"name":"AES-GCM","iv": iv_array}`).
  - Simplify plaintext/ciphertext marshaling by using `to_js` without the older `create_pyproxies=False` flags.

- decrypt_aes
  - Convert IV and algorithm via `to_js` with `dict_converter=js.Object.fromEntries`.
  - Convert ciphertext via `to_js` (simplified marshaling).
  - Derive/import key inside the decryption flow (removing precomputed key artifacts) and preserve existing error handling (returns `"[decryption error]"` on failure).

## Impact

- Ensures the Web Crypto API receives plain JS Objects (not Maps), eliminating the `undefined` algorithm error.
- Restores AES-256-GCM key import/encryption and fixes registration failures caused by the bug.
- No public API changes; backward compatibility maintained for existing encrypted data and error behaviors.

Lines changed: +19 / -16
<!-- end of auto-generated comment: release notes by coderabbit.ai -->