### PR TITLE
fix AES-GCM handling

### DIFF
--- a/src/worker.py
+++ b/src/worker.py
@@ -40,9 +40,14 @@ import os
 import re
 import traceback
 from urllib.parse import urlparse, parse_qs
-
 from workers import Response
+import js
+from pyodide.ffi import to_js
 
+
+def jso(obj):
+    """Utility to convert Python types to JS objects (Object.fromEntries for dicts)."""
+    return to_js(obj, create_pyproxies=False, dict_converter=js.Object.fromEntries)
 
 def capture_exception(exc: Exception, req=None, _env=None, where: str = ""):
     """Best-effort exception logging with full traceback and request context."""
@@ -109,12 +114,9 @@ def _derive_aes_key_bytes(secret: str) -> bytes:
 
 async def _import_aes_key(key_bytes: bytes) -> object:
     """Import raw bytes as a Web Crypto AES-GCM CryptoKey."""
-    import js
-    from pyodide.ffi import to_js
-    key_buf = to_js(key_bytes, create_pyproxies=False)
-    algo    = to_js({"name": "AES-GCM"}, create_pyproxies=False)
-    usages  = to_js(["encrypt", "decrypt"], create_pyproxies=False)
-    return await js.crypto.subtle.importKey("raw", key_buf, algo, False, usages)
+    return await js.crypto.subtle.importKey(
+        "raw", jso(key_bytes), jso({"name": "AES-GCM"}), False, jso(["encrypt", "decrypt"])
+    )
 
 
 async def encrypt_aes(plaintext: str, secret: str) -> str:
@@ -126,13 +128,11 @@ async def encrypt_aes(plaintext: str, secret: str) -> str:
     if not plaintext:
         return ""
     try:
-        import js
-        from pyodide.ffi import to_js
         key_bytes  = _derive_aes_key_bytes(secret)
         crypto_key = await _import_aes_key(key_bytes)
-        iv         = bytes(js.crypto.getRandomValues(to_js(bytearray(12))))
-        algo       = to_js({"name": "AES-GCM", "iv": to_js(iv)}, create_pyproxies=False)
-        data       = to_js(plaintext.encode("utf-8"), create_pyproxies=False)
+        iv         = bytes(js.crypto.getRandomValues(jso(bytearray(12))))
+        algo       = jso({"name": "AES-GCM", "iv": jso(iv)})
+        data       = jso(plaintext.encode("utf-8"))
         ct_buf     = await js.crypto.subtle.encrypt(algo, crypto_key, data)
         ct         = bytes(js.Uint8Array.new(ct_buf))
         return "v1:" + base64.b64encode(iv + ct).decode("ascii")
@@ -149,8 +149,6 @@ async def decrypt_aes(ciphertext: str, secret: str) -> str:
         return ""
     if not ciphertext.startswith("v1:"):
         return _decrypt_xor(ciphertext, secret)
-    import js
-    from pyodide.ffi import to_js
     try:
         raw        = base64.b64decode(ciphertext[3:])
         iv, ct     = raw[:12], raw[12:]
@@ -159,8 +157,8 @@ async def decrypt_aes(ciphertext: str, secret: str) -> str:
         return "[decryption error]"
     key_bytes  = _derive_aes_key_bytes(secret)
     crypto_key = await _import_aes_key(key_bytes)
-    algo       = to_js({"name": "AES-GCM", "iv": to_js(iv)}, create_pyproxies=False)
-    data       = to_js(ct, create_pyproxies=False)
+    algo       = jso({"name": "AES-GCM", "iv": jso(iv)})
+    data       = jso(ct)
     try:
         pt_buf = await js.crypto.subtle.decrypt(algo, crypto_key, data)
         return bytes(js.Uint8Array.new(pt_buf)).decode("utf-8")


### PR DESCRIPTION
# Abstract

Hello, this PR has the goal to fix the `_import_aes_key` since the last PR seems to have broken the encryption. This addresses a critical regression in the authenticated encryption layer of our Cloudflare Python Worker, ensuring all PII and sensitive data can be successfully protected and retrieved.

# Current problem

The `js.crypto.subtle.importKey` method (and other Web Crypto APIs) strictly requires a plain JavaScript **Object** for the algorithm parameter. However, by default, the Pyodide `to_js()` function converts Python dictionaries into JavaScript **Map** objects.

When a Map is passed where an Object is expected, the internal JavaScript engine fails to find the required properties (like `.name`), resulting in a `NotSupportedError: Unrecognized key import algorithm "undefined" requested`. This effectively broke all authenticated encryption paths in the application.

# Fix

The solution involves three main improvements:

1.  **Centralized Conversion**: Introduced a lightweight `jso()` helper that ensures all Python-to-JS conversions for "dictionary-like" parameters use `js.Object.fromEntries`. This guarantees that the Web Crypto API receives plain JS Objects.
2.  **Code Simplification**: Moved Pyodide/JS imports to the top level and refactored the crypto helpers to use the new `jso()` utility. This significantly reduced the verbosity and "noise" of the `to_js` calls.
3.  **Cleanup**: Removed redundant local imports.


https://github.com/user-attachments/assets/328b88a6-00ff-4533-a5ad-92e8bc0c2aae




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix for AES-GCM Encryption/Decryption

This PR fixes a regression in authenticated encryption handling in the Cloudflare Python Worker. The root cause was that Pyodide's `to_js()` function converts Python dictionaries to JavaScript Map objects, but the Web Crypto API requires plain JavaScript Objects for algorithm parameters, causing a `NotSupportedError` with "Unrecognized key import algorithm 'undefined'".

### Key Changes

1. **New `jso()` helper function**: Introduced a lightweight utility that wraps `to_js()` with `dict_converter=js.Object.fromEntries` to ensure Python dictionaries are converted to plain JavaScript Objects (not Map objects) that Web Crypto APIs can properly consume.

2. **Centralized imports**: Moved `import js` and `from pyodide.ffi import to_js` to the top level of the module, removing redundant per-function imports.

3. **Refactored crypto functions**: Updated three async functions to use the new `jso()` helper:
   - `_import_aes_key()`: Simplified key bytes, algorithm object, and usages array conversion
   - `encrypt_aes()`: Cleaned up IV generation, algorithm object, and plaintext buffer handling
   - `decrypt_aes()`: Simplified algorithm object and ciphertext buffer conversion

### Impact

The changes restore correct AES-GCM encryption and decryption functionality for protecting and retrieving PII and sensitive data in the authenticated encryption layer. The fix maintains backward compatibility with legacy XOR decryption while ensuring Web Crypto receives properly formatted parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->