### PR TITLE
perf: fix N+1 tag queries in activities and dashboard APIs

### DIFF
--- a/src/worker.py
+++ b/src/worker.py
@@ -654,9 +654,13 @@ async def api_list_activities(req, env):
         "a.created_at,u.name AS host_name_enc,"
         "(SELECT COUNT(*) FROM enrollments WHERE activity_id=a.id AND status='active')"
         " AS participant_count,"
-        "(SELECT COUNT(*) FROM sessions WHERE activity_id=a.id) AS session_count"
+        "(SELECT COUNT(*) FROM sessions WHERE activity_id=a.id) AS session_count,"
+        "GROUP_CONCAT(t.name) AS tag_names"
         " FROM activities a JOIN users u ON a.host_id=u.id"
+        " LEFT JOIN activity_tags at2 ON at2.activity_id=a.id"
+        " LEFT JOIN tags t ON t.id=at2.tag_id"
     )
+    group_order = " GROUP BY a.id ORDER BY a.created_at DESC"
 
     if tag:
         tag_row = await env.DB.prepare(
@@ -665,25 +669,23 @@ async def api_list_activities(req, env):
         if not tag_row:
             return json_resp({"activities": []})
         res = await env.DB.prepare(
-            base_q
-            + " JOIN activity_tags at2 ON at2.activity_id=a.id"
-              " WHERE at2.tag_id=? ORDER BY a.created_at DESC"
+            base_q + " WHERE at2.tag_id=?" + group_order
         ).bind(tag_row.id).all()
     elif atype and fmt:
         res = await env.DB.prepare(
-            base_q + " WHERE a.type=? AND a.format=? ORDER BY a.created_at DESC"
+            base_q + " WHERE a.type=? AND a.format=?" + group_order
         ).bind(atype, fmt).all()
     elif atype:
         res = await env.DB.prepare(
-            base_q + " WHERE a.type=? ORDER BY a.created_at DESC"
+            base_q + " WHERE a.type=?" + group_order
         ).bind(atype).all()
     elif fmt:
         res = await env.DB.prepare(
-            base_q + " WHERE a.format=? ORDER BY a.created_at DESC"
+            base_q + " WHERE a.format=?" + group_order
         ).bind(fmt).all()
     else:
         res = await env.DB.prepare(
-            base_q + " ORDER BY a.created_at DESC"
+            base_q + group_order
         ).all()
 
     activities = []
@@ -696,12 +698,6 @@ async def api_list_activities(req, env):
         ):
             continue
 
-        t_res = await env.DB.prepare(
-            "SELECT t.name FROM tags t"
-            " JOIN activity_tags at2 ON at2.tag_id=t.id"
-            " WHERE at2.activity_id=?"
-        ).bind(row.id).all()
-
         activities.append({
             "id":                row.id,
             "title":             row.title,
@@ -712,7 +708,7 @@ async def api_list_activities(req, env):
             "host_name":         host_name,
             "participant_count": row.participant_count,
             "session_count":     row.session_count,
-            "tags":              [t.name for t in (t_res.results or [])],
+            "tags":              row.tag_names.split(",") if row.tag_names else [],
             "created_at":        row.created_at,
         })
 
@@ -907,16 +903,16 @@ async def api_dashboard(req, env):
         "SELECT a.id,a.title,a.type,a.format,a.schedule_type,a.created_at,"
         "(SELECT COUNT(*) FROM enrollments WHERE activity_id=a.id AND status='active')"
         " AS participant_count,"
-        "(SELECT COUNT(*) FROM sessions WHERE activity_id=a.id) AS session_count"
-        " FROM activities a WHERE a.host_id=? ORDER BY a.created_at DESC"
+        "(SELECT COUNT(*) FROM sessions WHERE activity_id=a.id) AS session_count,"
+        "GROUP_CONCAT(t.name) AS tag_names"
+        " FROM activities a"
+        " LEFT JOIN activity_tags at2 ON at2.activity_id=a.id"
+        " LEFT JOIN tags t ON t.id=at2.tag_id"
+        " WHERE a.host_id=? GROUP BY a.id ORDER BY a.created_at DESC"
     ).bind(user["id"]).all()
 
     hosted = []
     for r in res.results or []:
-        t_res = await env.DB.prepare(
-            "SELECT t.name FROM tags t JOIN activity_tags at2 ON at2.tag_id=t.id"
-            " WHERE at2.activity_id=?"
-        ).bind(r.id).all()
         hosted.append({
             "id":                r.id,
             "title":             r.title,
@@ -925,26 +921,25 @@ async def api_dashboard(req, env):
             "schedule_type":     r.schedule_type,
             "participant_count": r.participant_count,
             "session_count":     r.session_count,
-            "tags":              [t.name for t in (t_res.results or [])],
+            "tags":              r.tag_names.split(",") if r.tag_names else [],
             "created_at":        r.created_at,
         })
 
     res2 = await env.DB.prepare(
         "SELECT a.id,a.title,a.type,a.format,a.schedule_type,"
         "e.role AS enr_role,e.status AS enr_status,e.created_at AS joined_at,"
-        "u.name AS host_name_enc"
+        "u.name AS host_name_enc,"
+        "GROUP_CONCAT(t.name) AS tag_names"
         " FROM enrollments e"
         " JOIN activities a ON e.activity_id=a.id"
         " JOIN users u ON a.host_id=u.id"
-        " WHERE e.user_id=? ORDER BY e.created_at DESC"
+        " LEFT JOIN activity_tags at2 ON at2.activity_id=a.id"
+        " LEFT JOIN tags t ON t.id=at2.tag_id"
+        " WHERE e.user_id=? GROUP BY a.id ORDER BY e.created_at DESC"
     ).bind(user["id"]).all()
 
     joined = []
     for r in res2.results or []:
-        t_res = await env.DB.prepare(
-            "SELECT t.name FROM tags t JOIN activity_tags at2 ON at2.tag_id=t.id"
-            " WHERE at2.activity_id=?"
-        ).bind(r.id).all()
         joined.append({
             "id":            r.id,
             "title":         r.title,
@@ -954,7 +949,7 @@ async def api_dashboard(req, env):
             "enr_role":      r.enr_role,
             "enr_status":    r.enr_status,
             "host_name":     decrypt(r.host_name_enc or "", enc),
-            "tags":          [t.name for t in (t_res.results or [])],
+            "tags":          r.tag_names.split(",") if r.tag_names else [],
             "joined_at":     r.joined_at,
         })
 


### PR DESCRIPTION
## Changes

The activities listing and dashboard APIs had an N+1 query problem. For every activity returned by the main query, a separate SQL query was fired just to fetch that activity's tags. So if there were 50 activities, the API would run 51 database queries (1 for activities + 50 for tags). On the dashboard it was even worse since it does this twice, once for hosted and once for joined activities.

Fixed this by using SQLite's `GROUP_CONCAT` to pull tags directly in the main query. The tags come back as a single comma-separated string per activity, which gets split into a list in Python. No extra queries needed.

Before: each activity page load hit the database N+1 times (1 main query + 1 per activity for tags)
After: always just 1 query for activities listing, 2 for dashboard (hosted + joined)

The fix touches three queries across two functions: `api_list_activities` (the homepage feed) and `api_dashboard` (the logged-in user's hosted and joined activities). The response format is unchanged so nothing breaks on the frontend.

## Testing

- Verified all 6 seed activities return the correct tags
- Checked multi-tag activities like "Data Science Workshop" correctly return both "Data Science" and "Python"
- Tested all filter combinations (by type, format, tag, and search) to make sure they still work
- Logged in as alice and confirmed the dashboard returns correct tags for hosted activities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes N+1 query inefficiencies in activity listing and dashboard endpoints by aggregating activity tags into the primary SQL queries.

Purpose
- Eliminate N+1 tag queries in api_list_activities (homepage feed) and api_dashboard (hosted + joined lists) to reduce DB round-trips and improve performance.

Key changes
- Main queries updated to LEFT JOIN activity_tags and tags and use GROUP_CONCAT(t.name) AS tag_names with GROUP BY a.id to return comma-separated tag names per activity.
- api_list_activities: tag filtering moved into the aggregated query; per-activity follow-up SELECTs to fetch tags removed. Python mapping now parses tags with row.tag_names.split(",") if present.
- api_dashboard: hosted and joined activity queries use GROUP_CONCAT(...) and GROUP BY a.id so hosted and joined lists are fetched in two queries (hosted + joined) instead of N+1 per list. Python mapping for hosted uses r.tag_names.split(",") as tags.
- Response shape unchanged: tags remain arrays in JSON.

Impact & notes
- Query count reduced: activities listing → 1 query total; dashboard → 2 queries (hosted + joined).
- Filters (type, format, tag, search) and multi-tag activities are preserved per tests included in the PR.
- Minor bug observed in current api_dashboard joined-activities mapping: it references t_res (from another scope) when building joined activity tags instead of parsing r.tag_names, which will cause incorrect/jumbled tag output for joined_activities. This should be corrected to: "tags": r.tag_names.split(",") if r.tag_names else [].
<!-- end of auto-generated comment: release notes by coderabbit.ai -->