### PR TITLE
fix: align password minlength in UI with backend validation

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -73,8 +73,8 @@
         </div>
         <div>
           <label class="block text-sm font-medium text-slate-700 mb-1">Password</label>
-          <input id="r-password" type="password" autocomplete="new-password" required minlength="6"
-            class="w-full px-4 py-2.5 rounded-xl border border-slate-200 focus:outline-none focus:ring-2 focus:ring-brand/40 text-sm" placeholder="min 6 characters" />
+          <input id="r-password" type="password" autocomplete="new-password" required minlength="8"
+            class="w-full px-4 py-2.5 rounded-xl border border-slate-200 focus:outline-none focus:ring-2 focus:ring-brand/40 text-sm" placeholder="min 8 characters" />
         </div>
         <p id="register-err" class="text-red-500 text-sm hidden"></p>
         <button type="submit" class="w-full bg-brand text-white font-semibold py-2.5 rounded-xl hover:bg-brand-dark transition text-sm">Create Account</button>


### PR DESCRIPTION
### Changes
- Fix password `minlength` attribute in registration form from `6` to `8`
- Fix placeholder text from "min 6 characters" to "min 8 characters"

### Why
The backend (`worker.py` line 655) rejects passwords shorter than 8 characters,
but the frontend registration form allowed submissions with as few as 6 characters.
This caused confusing silent failures for users — the browser accepted their
password but the server rejected it with no clear explanation.

### Testing
- Open `public/login.html` in browser
- Registration form password field now enforces minimum 8 characters client-side
- Matches backend validation in `worker.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR aligns the frontend password validation with the backend validation rules by updating the registration form's password field constraints.

## Changes

Updated `public/login.html` registration form password input:
- Changed `minlength` attribute from `6` to `8` characters
- Updated placeholder text from "min 6 characters" to "min 8 characters"

## Purpose

The backend validation in `worker.py` enforces a minimum password length of 8 characters. However, the frontend previously allowed passwords as short as 6 characters, resulting in silent server-side rejections when users submitted passwords that passed client-side validation but failed backend checks.

## Impact

This change provides immediate client-side feedback to users, preventing confusion from silent form submission failures. Users attempting to register with passwords shorter than 8 characters will now see the constraint enforced in the browser before attempting to submit, improving the registration experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->