### PR TITLE
fix: resolve AES-GCM Web Crypto interop failure in Pyodide worker

### DIFF
--- a/src/worker.py
+++ b/src/worker.py
@@ -1233,27 +1233,6 @@ async def serve_static(path: str, env):
     mime = _MIME.get(ext, "text/plain")
     return Response(content, headers={"Content-Type": mime, **_CORS})
 
-async def api_get_users(req, env):
-    try:
-        res = await env.DB.prepare(
-            "SELECT username FROM users"
-        ).all()
-
-        userData = []
-
-        for row in (res.results or []):
-            decrypted_username = await decrypt_aes(row.username, env.ENCRYPTION_KEY)
-
-            userData.append({
-                "username": decrypted_username
-            })
-
-        return ok({
-            "users": userData
-        })
-
-    except Exception as e:
-        return err(f"something went wrong: {e}", 500)
 
 # ---------------------------------------------------------------------------
 # Main dispatcher
@@ -1295,9 +1274,6 @@ async def _dispatch(request, env):
 
         if path == "/api/login" and method == "POST":
             return await api_login(request, env)
-        
-        if path == "/api/users" and method == "GET":
-            return await api_get_users(request, env)
 
         if path == "/api/activities" and method == "GET":
             return await api_list_activities(request, env)

--- a/src/worker.py
+++ b/src/worker.py
@@ -112,8 +112,9 @@ def _derive_aes_key_bytes(secret: str) -> bytes:
 async def _import_aes_key(key_bytes: bytes) -> object:
     """Import raw bytes as a Web Crypto AES-GCM CryptoKey."""
     key_buf = to_js(key_bytes, create_pyproxies=False)
-    algo    = {"name": "AES-GCM"}
-    usages  = to_js(["encrypt", "decrypt"])
+    algo = js.Object.new()
+    algo.name = "AES-GCM"
+    usages = to_js(["encrypt", "decrypt"])
     return await js.crypto.subtle.importKey("raw", key_buf, algo, False, usages)
 
 
@@ -121,6 +122,7 @@ async def encrypt_aes(plaintext: str, secret: str) -> str:
     """
     AES-256-GCM encryption using js.crypto.subtle (Web Crypto API).
     Returns "v1:" + base64(iv || ciphertext+tag).
+    Key is derived via PBKDF2-SHA256 (100k iterations) on every call.
     Raises RuntimeError on encryption failure — no silent XOR fallback.
     """
     if not plaintext:
@@ -129,16 +131,18 @@ async def encrypt_aes(plaintext: str, secret: str) -> str:
         key_bytes  = _derive_aes_key_bytes(secret)
         crypto_key = await _import_aes_key(key_bytes)
 
-        # Generate random IV directly into a JS Uint8Array for clean interop
-        iv_array   = js.Uint8Array.new(12)
+        iv_array = js.Uint8Array.new(12)
         js.crypto.getRandomValues(iv_array)
-        iv         = bytes(iv_array) # Extract back to python bytes for storage
+        iv = bytes(iv_array)
 
-        # Pass algo as a plain dict; Web Crypto accepts both JS objects and plain dicts
-        algo       = {"name": "AES-GCM", "iv": iv_array}
-        data       = to_js(plaintext.encode("utf-8"), create_pyproxies=False)
-        ct_buf     = await js.crypto.subtle.encrypt(algo, crypto_key, data)
-        ct         = bytes(js.Uint8Array.new(ct_buf))
+        # Build JS object so Web Crypto can read .name and .iv
+        algo = js.Object.new()
+        algo.name = "AES-GCM"
+        algo.iv = iv_array
+
+        data   = to_js(plaintext.encode("utf-8"), create_pyproxies=False)
+        ct_buf = await js.crypto.subtle.encrypt(algo, crypto_key, data)
+        ct     = bytes(js.Uint8Array.new(ct_buf))
         return "v1:" + base64.b64encode(iv + ct).decode("ascii")
     except Exception as exc:
         capture_exception(exc, where="encrypt_aes")
@@ -154,21 +158,26 @@ async def decrypt_aes(ciphertext: str, secret: str) -> str:
     if not ciphertext.startswith("v1:"):
         return _decrypt_xor(ciphertext, secret)
     try:
-        raw        = base64.b64decode(ciphertext[3:])
-        iv, ct     = raw[:12], raw[12:]
+        raw    = base64.b64decode(ciphertext[3:])
+        iv, ct = raw[:12], raw[12:]
     except Exception as exc:
         capture_exception(exc, where="decrypt_aes.decode")
         return "[decryption error]"
     try:
         key_bytes  = _derive_aes_key_bytes(secret)
         crypto_key = await _import_aes_key(key_bytes)
-        iv_array   = to_js(iv, create_pyproxies=False)
-        algo       = {"name": "AES-GCM", "iv": iv_array}
-        data       = to_js(ct, create_pyproxies=False)
-        pt_buf     = await js.crypto.subtle.decrypt(algo, crypto_key, data)
+
+        iv_array = to_js(iv, create_pyproxies=False)
+
+        # Build JS object so Web Crypto can read .name and .iv
+        algo = js.Object.new()
+        algo.name = "AES-GCM"
+        algo.iv = iv_array
+
+        data   = to_js(ct, create_pyproxies=False)
+        pt_buf = await js.crypto.subtle.decrypt(algo, crypto_key, data)
         return bytes(js.Uint8Array.new(pt_buf)).decode("utf-8")
     except Exception as exc:
-        # Auth tag mismatch = tampered/corrupted ciphertext
         capture_exception(exc, where="decrypt_aes.auth")
         return "[decryption error]"
 
@@ -1224,6 +1233,27 @@ async def serve_static(path: str, env):
     mime = _MIME.get(ext, "text/plain")
     return Response(content, headers={"Content-Type": mime, **_CORS})
 
+async def api_get_users(req, env):
+    try:
+        res = await env.DB.prepare(
+            "SELECT username FROM users"
+        ).all()
+
+        userData = []
+
+        for row in (res.results or []):
+            decrypted_username = await decrypt_aes(row.username, env.ENCRYPTION_KEY)
+
+            userData.append({
+                "username": decrypted_username
+            })
+
+        return ok({
+            "users": userData
+        })
+
+    except Exception as e:
+        return err(f"something went wrong: {e}", 500)
 
 # ---------------------------------------------------------------------------
 # Main dispatcher
@@ -1265,6 +1295,9 @@ async def _dispatch(request, env):
 
         if path == "/api/login" and method == "POST":
             return await api_login(request, env)
+        
+        if path == "/api/users" and method == "GET":
+            return await api_get_users(request, env)
 
         if path == "/api/activities" and method == "GET":
             return await api_list_activities(request, env)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,9 +112,26 @@ class _Crypto:
         return b"\x00" * 12
 
 
+class _JsObject:
+    """Stub for a plain JS object created via ``js.Object.new()``.
+
+    Supports arbitrary attribute assignment, mirroring a vanilla JS object.
+    """
+    pass
+
+
+class _JsObjectClass:
+    """Stub for ``js.Object`` — only ``new()`` is needed by worker.py."""
+
+    @staticmethod
+    def new():
+        return _JsObject()
+
+
 class _JsModule:
     crypto = _Crypto()
     Uint8Array = _Uint8Array()
+    Object = _JsObjectClass()
 
 
 sys.modules["js"] = _JsModule()


### PR DESCRIPTION
## Problem
All `encrypt_aes` and `decrypt_aes` calls were failing with `NotSupportedError: Unrecognized key import algorithm "undefined"`. This leads to user registration failure. Previously this issue was already addressed in #27 and PR was merged but after a further commit [8ac4409...](https://github.com/alphaonelabs/learn/commit/8ac440924195f485dacb678851a26f83f7c44e9c) , this reintroduced the AES bug.

<p align='center'>
<img width="600" height="600" alt="image" src="https://github.com/user-attachments/assets/49affb09-df4a-4988-b716-7e9753dcbf20" />
</p>

## Root Cause
In Pyodide, passing a bare Python dict to `js.crypto.subtle` APIs does not produce a plain JS object. Without an explicit converter, `to_js({"name": "AES-GCM"})` produces a JS Map. The Web Crypto API reads algorithm parameters via dot-notation (`e.g. algo.name`), which returns undefined on a Map, and hence the error.

The previous correct fix used `dict_converter=js.Object.fromEntries`. Commit [8ac4409](https://github.com/alphaonelabs/learn/commit/8ac440924195f485dacb678851a26f83f7c44e9c) removed that, leaving raw Python dicts and rebreaking everything.

## FIx
Replaced all three algorithm parameter constructions in `_import_aes_key`, `encrypt_aes`, and `decrypt_aes` with `js.Object.new()` instances, setting .name and .iv as explicit JS properties.

### Aditionally:
I've added `_JsObject` and `_JsObjectClass` stubs so that `js.Object.new()` works in the test environment.