### PR TITLE
feat: implement auth guards and conditional rendering entry button for virtual classroom

### DIFF
--- a/public/classroom_poc.html
+++ b/public/classroom_poc.html
@@ -235,6 +235,19 @@
     const desksContainer      = document.getElementById('desksContainer');
     const toastContainer      = document.getElementById('toastContainer');
 
+    // Authentication utils
+    function getAuth() {
+        return {
+            token: localStorage.getItem('edu_token'),
+            user: JSON.parse(localStorage.getItem('edu_user') || 'null')
+        };
+    }
+
+    function isAuthenticated() {
+        const { token, user } = getAuth();
+        return token && user;
+    }
+
     // COORDINATE HELPERS
     // Positions are stored and transmitted as NORMALIZED values (0.0 – 1.0)
     // representing a fraction of the canvas width/height.
@@ -414,6 +427,11 @@
 
     // Join / Leave
     function joinClassroom() {
+        if (!isAuthenticated()) {
+            alert('You must be signed in to join the virtual classroom.');
+            window.location.href = '/login.html';
+            return;
+        }
         intentionalDisconnect = false;
         reconnectAttempts = 0;
         isSeated = false;

--- a/public/classroom_poc.html
+++ b/public/classroom_poc.html
@@ -428,8 +428,12 @@
     // Join / Leave
     function joinClassroom() {
         if (!isAuthenticated()) {
-            alert('You must be signed in to join the virtual classroom.');
-            window.location.href = '/login.html';
+            showToast('Please sign in to join the virtual classroom.', 'warning');
+            // Preserve the user's intended destination so login.html can send
+            // them back here after authentication.
+            const returnTo = window.location.pathname + window.location.search;
+            sessionStorage.setItem('post_login_redirect', returnTo);
+            setTimeout(() => { window.location.href = '/login.html'; }, 800);
             return;
         }
         intentionalDisconnect = false;

--- a/public/index.html
+++ b/public/index.html
@@ -153,9 +153,14 @@
                                 </div>
                                 <span>21 learners inside</span>
                             </div>
-                            <a href="/classroom_poc.html?autojoin=1&room=lobby" class="w-full bg-white text-teal-700 font-bold px-6 py-3 rounded-xl hover:bg-teal-50 transition-all shadow-lg flex items-center justify-center gap-2">
-                                <i class="fas fa-door-open"></i> Join Lobby Classroom
-                            </a>
+                            <div id="classroom-join-container">
+                                <a href="/classroom_poc.html?autojoin=1&room=lobby" class="w-full bg-white text-teal-700 font-bold px-6 py-3 rounded-xl hover:bg-teal-50 transition-all shadow-lg flex items-center justify-center gap-2" id="join-logged-in">
+                                    <i class="fas fa-door-open"></i> Join Lobby Classroom
+                                </a>
+                                <a href="/login.html" class="w-full bg-white/20 text-white font-bold px-6 py-3 rounded-xl hover:bg-white hover:text-black transition-all shadow-lg flex items-center justify-center gap-2" id="join-not-logged-in" style="display: none;">
+                                    <i class="fas fa-sign-in-alt"></i> Login to Join Classroom
+                                </a>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/public/index.html
+++ b/public/index.html
@@ -154,10 +154,10 @@
                                 <span>21 learners inside</span>
                             </div>
                             <div id="classroom-join-container">
-                                <a href="/classroom_poc.html?autojoin=1&room=lobby" class="w-full bg-white text-teal-700 font-bold px-6 py-3 rounded-xl hover:bg-teal-50 transition-all shadow-lg flex items-center justify-center gap-2" id="join-logged-in">
+                                <a href="/classroom_poc.html?autojoin=1&room=lobby" class="w-full bg-white text-teal-700 font-bold px-6 py-3 rounded-xl hover:bg-teal-50 transition-all shadow-lg flex items-center justify-center gap-2" id="join-logged-in" style="display: none;">
                                     <i class="fas fa-door-open"></i> Join Lobby Classroom
                                 </a>
-                                <a href="/login.html" class="w-full bg-white/20 text-white font-bold px-6 py-3 rounded-xl hover:bg-white hover:text-black transition-all shadow-lg flex items-center justify-center gap-2" id="join-not-logged-in" style="display: none;">
+                                <a href="/login.html?next=%2Fclassroom_poc.html%3Fautojoin%3D1%26room%3Dlobby" class="w-full bg-white/20 text-white font-bold px-6 py-3 rounded-xl hover:bg-white hover:text-black transition-all shadow-lg flex items-center justify-center gap-2" id="join-not-logged-in" style="display: none;">
                                     <i class="fas fa-sign-in-alt"></i> Login to Join Classroom
                                 </a>
                             </div>

--- a/public/js/layout.js
+++ b/public/js/layout.js
@@ -179,3 +179,18 @@ document.addEventListener('DOMContentLoaded', async () => {
     await inject('site-footer', '/partials/footer.html');
      updateDarkModeIcon();
 });
+
+// conditional rendering for the join lobby classroom btn
+document.addEventListener('DOMContentLoaded', function() {
+    const loggedInEl = document.getElementById('join-logged-in');
+    const notLoggedInEl = document.getElementById('join-not-logged-in');
+    const token = localStorage.getItem('edu_token');
+    const user = JSON.parse(localStorage.getItem('edu_user') || 'null');
+    if (token && user) {
+        loggedInEl.style.display = 'flex';
+        notLoggedInEl.style.display = 'none';
+    } else {
+        loggedInEl.style.display = 'none';
+        notLoggedInEl.style.display = 'flex';
+    }
+});

--- a/public/js/layout.js
+++ b/public/js/layout.js
@@ -180,17 +180,14 @@ document.addEventListener('DOMContentLoaded', async () => {
      updateDarkModeIcon();
 });
 
-// conditional rendering for the join lobby classroom btn
-document.addEventListener('DOMContentLoaded', function() {
+// Conditional rendering for the "Join Lobby Classroom" button.
+// These elements only exist on the homepage, so we guard against nulls.
+document.addEventListener('DOMContentLoaded', () => {
     const loggedInEl = document.getElementById('join-logged-in');
     const notLoggedInEl = document.getElementById('join-not-logged-in');
-    const token = localStorage.getItem('edu_token');
-    const user = JSON.parse(localStorage.getItem('edu_user') || 'null');
-    if (token && user) {
-        loggedInEl.style.display = 'flex';
-        notLoggedInEl.style.display = 'none';
-    } else {
-        loggedInEl.style.display = 'none';
-        notLoggedInEl.style.display = 'flex';
-    }
+    if (!loggedInEl || !notLoggedInEl) return;
+
+    const authed = isAuthenticated();
+    loggedInEl.style.display = authed ? 'flex' : 'none';
+    notLoggedInEl.style.display = authed ? 'none' : 'flex';
 });

--- a/public/login.html
+++ b/public/login.html
@@ -256,11 +256,32 @@ function switchTab(tab) {
             : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300');
 }
 
-// Store authentication data
+// Store authentication data and handle post-login flow
 function storeAuth(data) {
     localStorage.setItem('edu_token', data.token);
     localStorage.setItem('edu_user', JSON.stringify(data.user));
-    window.location.href = '/dashboard.html';
+    
+    // Show success toast
+    showToast('Redirecting...');
+    
+    // Wait a few seconds then redirect
+    setTimeout(() => {
+        handlePostLoginRedirect();
+    }, 500);
+}
+
+// Show success toast message
+function showToast(msg) {
+    const toast = document.createElement('div');
+    toast.className = 'fixed top-4 right-4 bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 rounded-lg p-4 text-green-700 dark:text-green-300 text-sm flex items-start gap-2 animate-pulse shadow-lg z-50';
+    toast.innerHTML = `
+        <i class="fas fa-check-circle mt-0.5 flex-shrink-0"></i>
+        <span>${msg}</span>
+    `;
+    document.body.appendChild(toast);
+    setTimeout(() => {
+        toast.remove();
+    }, 3000);
 }
 
 // Show error message
@@ -274,10 +295,31 @@ function showErr(id, msg) {
     }, 5000);
 }
 
+// Handle redirect after successful login
+function handlePostLoginRedirect() {
+    // Check if there's a stored redirect URL
+    const redirectUrl = sessionStorage.getItem('post_login_redirect');
+    
+    if (redirectUrl) {
+        // Clear it so it doesn't trigger again
+        sessionStorage.removeItem('post_login_redirect');
+        // Redirect to the original destination
+        window.location.href = redirectUrl;
+    } else {
+        // Default redirect
+        window.location.href = '/dashboard.html';
+    }
+}
+
 // Handle tab parameter in URL
 const params = new URLSearchParams(location.search);
 if (params.get('tab') === 'register') {
     switchTab('register');
+}
+
+// Handle next parameter for post-login redirect
+if (params.get('next')) {
+    sessionStorage.setItem('post_login_redirect', decodeURIComponent(params.get('next')));
 }
 
 // Login form submission

--- a/public/login.html
+++ b/public/login.html
@@ -274,10 +274,11 @@ function storeAuth(data) {
 function showToast(msg) {
     const toast = document.createElement('div');
     toast.className = 'fixed top-4 right-4 bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 rounded-lg p-4 text-green-700 dark:text-green-300 text-sm flex items-start gap-2 animate-pulse shadow-lg z-50';
-    toast.innerHTML = `
-        <i class="fas fa-check-circle mt-0.5 flex-shrink-0"></i>
-        <span>${msg}</span>
-    `;
+    const icon = document.createElement('i');
+    icon.className = 'fas fa-check-circle mt-0.5 flex-shrink-0';
+    const span = document.createElement('span');
+    span.textContent = msg;
+    toast.append(icon, span);
     document.body.appendChild(toast);
     setTimeout(() => {
         toast.remove();
@@ -297,18 +298,11 @@ function showErr(id, msg) {
 
 // Handle redirect after successful login
 function handlePostLoginRedirect() {
-    // Check if there's a stored redirect URL
     const redirectUrl = sessionStorage.getItem('post_login_redirect');
-    
-    if (redirectUrl) {
-        // Clear it so it doesn't trigger again
-        sessionStorage.removeItem('post_login_redirect');
-        // Redirect to the original destination
-        window.location.href = redirectUrl;
-    } else {
-        // Default redirect
-        window.location.href = '/dashboard.html';
-    }
+    sessionStorage.removeItem('post_login_redirect');
+    // Only honor same-origin, path-only redirects to prevent open-redirect abuse.
+    const safe = redirectUrl && /^\/(?!\/)/.test(redirectUrl);
+    window.location.href = safe ? redirectUrl : '/dashboard.html';
 }
 
 // Handle tab parameter in URL
@@ -317,9 +311,11 @@ if (params.get('tab') === 'register') {
     switchTab('register');
 }
 
-// Handle next parameter for post-login redirect
-if (params.get('next')) {
-    sessionStorage.setItem('post_login_redirect', decodeURIComponent(params.get('next')));
+// Handle next parameter for post-login redirect.
+// URLSearchParams.get() already performs percent-decoding — no need to decode again.
+const nextParam = params.get('next');
+if (nextParam) {
+    sessionStorage.setItem('post_login_redirect', nextParam);
 }
 
 // Login form submission


### PR DESCRIPTION
## Description
This PR introduces necessary authentication guards and UX improvements for the Virtual Classroom entry points to prevent unauthorized access and console errors.

- **Conditional UI (Homepage):** Conditionally rendering the `Join Lobby Classroom` button. Unauthenticated users will now see a prompt to login instead of redirecting to the classroom.

- **Classroom Auth Guard:** Added validation logic to the frontend. If a user attempts to bypass the homepage and directly access the classroom URL without an active session, they are alerted and automatically redirected to the login page.

Logged In:
<img width="602" height="308" alt="Screenshot 2026-04-22 at 6 37 12 PM" src="https://github.com/user-attachments/assets/d828af5a-6ab4-498a-ba3b-44733a957ddf" />

Logged Out:
<img width="554" height="280" alt="Screenshot 2026-04-22 at 6 37 26 PM" src="https://github.com/user-attachments/assets/25a3aab5-fe9e-4cd9-a393-5bed9dedfc9c" />

alert:
<img width="1470" height="956" alt="Screenshot 2026-04-22 at 11 02 43 PM" src="https://github.com/user-attachments/assets/03b4b883-b59d-4ace-84bc-97f301d5c4af" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Purpose
Implements client-side authentication guards and conditional UI for the Virtual Classroom entry flow to prevent unauthorized access and provide clearer UX for authenticated vs unauthenticated users.

## Key Changes
- public/classroom_poc.html
  - Added authentication helpers: getAuth() (reads edu_token and parses edu_user from localStorage) and isAuthenticated().
  - Updated joinClassroom() to enforce an auth guard: if not authenticated, show a warning toast, save current path+query to sessionStorage.post_login_redirect, and redirect to /login.html after ~800ms; aborts the join flow to avoid console errors and unauthorized access.
- public/index.html
  - Replaced single "Join Lobby Classroom" anchor with a hidden dual-state container (#join-logged-in, #join-not-logged-in). Links point to the classroom autojoin and to login with a next parameter respectively.
- public/js/layout.js
  - Added getAuth(), isAuthenticated(), and logout() utilities.
  - Added DOMContentLoaded logic that conditionally displays the appropriate homepage button: authenticated users see "Join Lobby Classroom"; unauthenticated users see "Login to Join Classroom".
  - updateAuthSection integration preserved for navbar/profile handling.
- public/login.html
  - storeAuth(data) now shows a "Redirecting..." toast and defers navigation to handlePostLoginRedirect() (500ms delay) instead of immediately navigating to dashboard.
  - Added showToast(msg) UI helper and handlePostLoginRedirect() which reads sessionStorage.post_login_redirect (or falls back to /dashboard.html). Also stores a provided next query parameter into sessionStorage.post_login_redirect when present.

## Impact
- Functionality: Prevents unauthenticated direct access to the classroom page and aborts the join flow early to avoid runtime errors; preserves post-login redirect so users return to their intended classroom.
- UX: Homepage shows context-appropriate CTAs (join vs login), login flow displays a toast and redirects back to the classroom when applicable, and unauthenticated join attempts display a warning notification before redirecting.
- Backwards compatibility / APIs: No exported/public signature changes; changes are low-risk and limited to frontend client behavior.

## Notes
- Auth checks are client-side (localStorage-based); server-side enforcement is still recommended for security-sensitive endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->