### PR TITLE
fix: replace 3.10 union syntax to resolve pytest collection failures

### DIFF
--- a/src/worker.py
+++ b/src/worker.py
@@ -40,7 +40,7 @@ import os
 import re
 import traceback
 from types import SimpleNamespace
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 from urllib.parse import urlparse, parse_qs
 
 from workers import Response, DurableObject
@@ -2147,7 +2147,7 @@ async def on_fetch(request, env):
 # ---------------------------------------------------------------------------
 
 async def _create_notification(env, user_id: str, type_: str, title: str,
-                                message: str, related_id: str | None = None) -> None:
+                                message: str, related_id: Optional[str] = None) -> None:
     """Internal helper called by other handlers to create a notification.
 
     Silently swallows errors so a notification failure never breaks the


### PR DESCRIPTION
### Description
This PR fixes a `TypeError` during `pytest` test collection caused by using Python 3.10+ type union syntax (`str | None`) in a Python 3.9 environment. The codebase targets Python 3.9.6, which does not support the `|` union operator for type hints. 

<img width="2973" height="2377" alt="image" src="https://github.com/user-attachments/assets/c324d4db-a489-4766-8e85-a8887e1e9472" />

Reverting this to `Optional[str]` maintains the intended type safety while restoring compatibility.

### Changes Made
- Added `Optional` to typing imports in `worker.py`
- Replaced `str | None` with `Optional[str]` in the `_create_notification` function signature.

## All 273 tests now collect and execute successfully with zero breaking changes to functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR resolves pytest test collection failures caused by using Python 3.10+ union type syntax (`str | None`) in a codebase targeting Python 3.9.6. 

## Changes

The type hint in the `_create_notification` helper function in `src/worker.py` has been updated:
- Replaced `str | None` with `Optional[str]` for the `related_id` parameter
- Added `Optional` to the typing imports

## Impact

- **Compatibility**: Restores compatibility with Python 3.9.6 by using the legacy union type syntax
- **Functionality**: No functional changes; the type semantics remain identical
- **Test Coverage**: Resolves test collection failures, allowing all 273 tests to collect and execute successfully
- **Scope**: Internal change only—no impact to public APIs or exported entities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->