### PR TITLE
Add Alpha One Labs Linkedin Handle in Footer

### DIFF
--- a/public/partials/footer.html
+++ b/public/partials/footer.html
@@ -47,6 +47,9 @@
                         <a href="https://instagram.com/alphaonelabs1" target="_blank" rel="noopener noreferrer" class="flex items-center justify-center h-10 w-10 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-teal-100 dark:hover:bg-teal-900 hover:text-teal-600 dark:hover:text-teal-400 transition-colors">
                             <i class="fab fa-instagram text-xl"></i>
                         </a>
+                        <a href="https://www.linkedin.com/company/alpha-one-labs" target="_blank" rel="noopener noreferrer" class="flex items-center justify-center h-10 w-10 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-teal-100 dark:hover:bg-teal-900 hover:text-teal-600 dark:hover:text-teal-400 transition-colors">
+                            <i class="fab fa-linkedin text-xl"></i>
+                        </a>
                         <a href="https://facebook.com/alphaonelabs" target="_blank" rel="noopener noreferrer" class="flex items-center justify-center h-10 w-10 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-teal-100 dark:hover:bg-teal-900 hover:text-teal-600 dark:hover:text-teal-400 transition-colors">
                             <i class="fab fa-facebook text-xl"></i>
                         </a>

--- a/public/partials/footer.html
+++ b/public/partials/footer.html
@@ -47,7 +47,7 @@
                         <a href="https://instagram.com/alphaonelabs1" target="_blank" rel="noopener noreferrer" class="flex items-center justify-center h-10 w-10 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-teal-100 dark:hover:bg-teal-900 hover:text-teal-600 dark:hover:text-teal-400 transition-colors">
                             <i class="fab fa-instagram text-xl"></i>
                         </a>
-                        <a href="https://www.linkedin.com/company/alpha-one-labs" target="_blank" rel="noopener noreferrer" class="flex items-center justify-center h-10 w-10 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-teal-100 dark:hover:bg-teal-900 hover:text-teal-600 dark:hover:text-teal-400 transition-colors">
+                        <a href="https://www.linkedin.com/company/alpha-one-labs" target="_blank" rel="noopener noreferrer" aria-label="Visit Alpha One Labs on LinkedIn" class="flex items-center justify-center h-10 w-10 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-teal-100 dark:hover:bg-teal-900 hover:text-teal-600 dark:hover:text-teal-400 transition-colors">
                             <i class="fab fa-linkedin text-xl"></i>
                         </a>
                         <a href="https://facebook.com/alphaonelabs" target="_blank" rel="noopener noreferrer" class="flex items-center justify-center h-10 w-10 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-teal-100 dark:hover:bg-teal-900 hover:text-teal-600 dark:hover:text-teal-400 transition-colors">


### PR DESCRIPTION
<img width="1617" height="598" alt="image" src="https://github.com/user-attachments/assets/b9725462-1c09-4c25-9fe9-a9018a53aae4" />

closes #58 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds LinkedIn as a new social media connection option to the site footer. A LinkedIn icon and link have been added to the "CONNECT WITH US" section, positioned between Instagram and Facebook icons.

## Changes

**public/partials/footer.html**
- Added a new LinkedIn social media link (`https://www.linkedin.com/company/alpha-one-labs`) with the Font Awesome LinkedIn icon (`fab fa-linkedin`)
- Link opens in a new tab with appropriate security attributes (`target="_blank"` and `rel="noopener noreferrer"`)
- LinkedIn button styled consistently with existing social icons using the same circular button design, color scheme, and dark mode support
- Positioned within the flex container of social icons in the footer

## Impact

This is a low-impact change that enhances the site's social media presence by adding a professional networking platform link. The addition maintains the existing visual design and layout consistency while providing users with an additional connection point to reach Alpha One Labs on LinkedIn.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->