### PR TITLE
Notifications system wiring + preferences, UI, and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ Thumbs.db
 .idea/
 *.swp
 .env*
+
+# Local reference folder
+_django_ref/

--- a/public/js/layout.js
+++ b/public/js/layout.js
@@ -227,15 +227,38 @@ document.addEventListener('click', (event) => {
     }
 });
 
+function applyUnreadBadgeCount(count) {
+    const badge = document.getElementById('notif-unread-badge');
+    if (!badge) return;
+    if (count > 0) {
+        badge.textContent = count > 99 ? '99+' : String(count);
+        badge.classList.remove('hidden');
+        badge.setAttribute('aria-label', `${count} unread notifications`);
+    } else {
+        badge.classList.add('hidden');
+        badge.setAttribute('aria-label', '');
+    }
+    const link = document.getElementById('notif-bell-link');
+    if (link) {
+        link.setAttribute('aria-label', count > 0 ? `Notifications, ${count} unread` : 'Notifications');
+    }
+}
+
+window.applyUnreadBadgeCount = applyUnreadBadgeCount;
+
 // ── Initialize on DOM ready ───────────────────────────────────────────
+let layoutInitPromise = null;
+
 async function initLayout() {
-    initializeDarkMode();
-    await inject('site-navbar', '/partials/navbar.html', () => {
-        updateAuthSection();
-        if (window.refreshUnreadBadge) window.refreshUnreadBadge();
-    });
-    await inject('site-footer', '/partials/footer.html');
-    updateDarkModeIcon();
+    if (!layoutInitPromise) {
+        layoutInitPromise = (async () => {
+            initializeDarkMode();
+            await inject('site-navbar', '/partials/navbar.html', updateAuthSection);
+            await inject('site-footer', '/partials/footer.html');
+            updateDarkModeIcon();
+        })();
+    }
+    return layoutInitPromise;
 }
 
 window.initLayout = initLayout;

--- a/public/js/layout.js
+++ b/public/js/layout.js
@@ -17,9 +17,9 @@ function logout() {
     window.location.href = '/login.html';
 }
 
-function esc(s) {
+window.esc = window.esc || function (s) {
     return String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
+};
 
 // ── Dark mode utilities ───────────────────────────────────────────────
 window.toggleDarkMode = function () {
@@ -109,14 +109,69 @@ function updateAuthSection() {
         
         if (mobileAvatarEl) mobileAvatarEl.textContent = firstLetter;
         if (mobileGreetingEl) mobileGreetingEl.textContent = `Hi, ${firstName}`;
+
+        startUnreadPolling();
     } else {
         // User is not logged in
         if (notLoggedInDiv) notLoggedInDiv.classList.remove('hidden');
         if (loggedInDiv) loggedInDiv.classList.add('hidden');
         if (mobileNotLoggedIn) mobileNotLoggedIn.classList.remove('hidden');
         if (mobileLoggedIn) mobileLoggedIn.classList.add('hidden');
+
+        const badge = document.getElementById('notif-unread-badge');
+        if (badge) badge.classList.add('hidden');
+        stopUnreadPolling();
     }
 }
+
+window.updateAuthSection = updateAuthSection;
+
+async function refreshUnreadBadge() {
+    const badge = document.getElementById('notif-unread-badge');
+    const { token } = getAuth();
+    if (!badge) return;
+    if (!token) {
+        badge.classList.add('hidden');
+        return;
+    }
+    try {
+        const res = await fetch('/api/notifications/unread-count', {
+            headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) return;
+        const body = await res.json();
+        const count = (body.data && body.data.unread_count) || 0;
+        if (count > 0) {
+            badge.textContent = count > 99 ? '99+' : String(count);
+            badge.classList.remove('hidden');
+        } else {
+            badge.classList.add('hidden');
+        }
+    } catch (_) {
+        /* ignore */
+    }
+}
+
+window.refreshUnreadBadge = refreshUnreadBadge;
+
+var unreadPollTimer = null;
+
+function startUnreadPolling() {
+    if (unreadPollTimer) return;
+    unreadPollTimer = setInterval(() => {
+        refreshUnreadBadge();
+    }, 5000);
+    refreshUnreadBadge();
+}
+
+function stopUnreadPolling() {
+    if (!unreadPollTimer) return;
+    clearInterval(unreadPollTimer);
+    unreadPollTimer = null;
+}
+
+window.startUnreadPolling = startUnreadPolling;
+window.stopUnreadPolling = stopUnreadPolling;
 
 // ── Mobile menu toggle ────────────────────────────────────────────────
 window.toggleMobileMenu = function () {
@@ -173,12 +228,23 @@ document.addEventListener('click', (event) => {
 });
 
 // ── Initialize on DOM ready ───────────────────────────────────────────
-document.addEventListener('DOMContentLoaded', async () => {
+async function initLayout() {
     initializeDarkMode();
-    await inject('site-navbar', '/partials/navbar.html', updateAuthSection);
+    await inject('site-navbar', '/partials/navbar.html', () => {
+        updateAuthSection();
+        if (window.refreshUnreadBadge) window.refreshUnreadBadge();
+    });
     await inject('site-footer', '/partials/footer.html');
-     updateDarkModeIcon();
-});
+    updateDarkModeIcon();
+}
+
+window.initLayout = initLayout;
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initLayout);
+} else {
+    initLayout();
+}
 
 // Conditional rendering for the "Join Lobby Classroom" button.
 // These elements only exist on the homepage, so we guard against nulls.

--- a/public/notification-preferences.html
+++ b/public/notification-preferences.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Notification preferences - Alpha One Labs">
+  <title>Notification Preferences - Alpha One Labs</title>
+  <link rel="icon" type="image/png" href="https://alphaonelabs.com/static/images/logo.png" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+  <script>
+    tailwind.config = { darkMode: 'class', theme: { extend: {} } };
+    (function () {
+      if (localStorage.getItem('darkMode') === 'true') document.documentElement.classList.add('dark');
+    })();
+  </script>
+</head>
+<body class="min-h-screen flex flex-col bg-white text-gray-900 dark:bg-black dark:text-gray-100 transition-colors duration-300 overflow-x-hidden">
+
+  <div id="site-navbar"></div>
+
+  <main class="flex-1 max-w-2xl w-full mx-auto px-4 py-12">
+    <h1 class="text-3xl font-bold mb-2">Notification preferences</h1>
+    <p class="text-gray-600 dark:text-gray-400 mb-8">Choose which in-app notifications you receive.</p>
+
+    <div id="status" class="hidden mb-4 p-3 rounded-lg text-sm"></div>
+
+    <form id="prefs-form" class="space-y-6 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-6 shadow-md">
+      <label class="flex items-center justify-between gap-4 cursor-pointer">
+        <span>
+          <span class="font-semibold block">Enrollment updates</span>
+          <span class="text-sm text-gray-500 dark:text-gray-400">Join confirmations and new participants on your activities</span>
+        </span>
+        <input type="checkbox" id="enrollment_notify" class="h-5 w-5 rounded text-teal-600 focus:ring-teal-500" />
+      </label>
+      <label class="flex items-center justify-between gap-4 cursor-pointer">
+        <span>
+          <span class="font-semibold block">Session updates</span>
+          <span class="text-sm text-gray-500 dark:text-gray-400">New sessions scheduled for activities you joined</span>
+        </span>
+        <input type="checkbox" id="session_notify" class="h-5 w-5 rounded text-teal-600 focus:ring-teal-500" />
+      </label>
+      <label class="flex items-center justify-between gap-4 cursor-pointer">
+        <span>
+          <span class="font-semibold block">System messages</span>
+          <span class="text-sm text-gray-500 dark:text-gray-400">Welcome messages and activity publishing confirmations</span>
+        </span>
+        <input type="checkbox" id="system_notify" class="h-5 w-5 rounded text-teal-600 focus:ring-teal-500" />
+      </label>
+      <div class="flex flex-wrap gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+        <button type="submit" class="px-6 py-2 rounded-lg bg-teal-600 hover:bg-teal-700 text-white font-semibold">
+          Save preferences
+        </button>
+        <a href="/notifications.html" class="px-6 py-2 rounded-lg border border-gray-300 dark:border-gray-600 font-medium hover:bg-gray-50 dark:hover:bg-gray-900">
+          Back to notifications
+        </a>
+      </div>
+    </form>
+  </main>
+
+  <div id="site-footer"></div>
+
+  <script src="/js/layout.js" defer></script>
+  <script>
+    const API = '';
+    const token = localStorage.getItem('edu_token');
+    const esc = window.esc || (s => String(s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;'));
+
+    if (!token) window.location.href = '/login.html';
+
+    function showStatus(msg, ok) {
+      const el = document.getElementById('status');
+      el.textContent = msg;
+      el.className = 'mb-4 p-3 rounded-lg text-sm ' + (ok
+        ? 'bg-green-50 dark:bg-green-900/30 text-green-800 dark:text-green-200 border border-green-200 dark:border-green-800'
+        : 'bg-red-50 dark:bg-red-900/30 text-red-800 dark:text-red-200 border border-red-200 dark:border-red-800');
+      el.classList.remove('hidden');
+    }
+
+    async function loadPrefs() {
+      const res = await fetch(`${API}/api/notification-preferences`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.status === 401) {
+        window.location.href = '/login.html';
+        return;
+      }
+      if (!res.ok) throw new Error('Failed to load preferences');
+      const body = await res.json();
+      const p = body.data || {};
+      document.getElementById('enrollment_notify').checked = !!p.enrollment_notify;
+      document.getElementById('session_notify').checked = !!p.session_notify;
+      document.getElementById('system_notify').checked = !!p.system_notify;
+    }
+
+    document.getElementById('prefs-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const payload = {
+        enrollment_notify: document.getElementById('enrollment_notify').checked,
+        session_notify: document.getElementById('session_notify').checked,
+        system_notify: document.getElementById('system_notify').checked,
+      };
+      const res = await fetch(`${API}/api/notification-preferences`, {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        showStatus(err.error || 'Save failed', false);
+        return;
+      }
+      showStatus('Preferences saved.', true);
+    });
+
+    loadPrefs().catch(err => showStatus(esc(err.message), false));
+  </script>
+</body>
+</html>

--- a/public/notification-preferences.html
+++ b/public/notification-preferences.html
@@ -23,7 +23,7 @@
     <h1 class="text-3xl font-bold mb-2">Notification preferences</h1>
     <p class="text-gray-600 dark:text-gray-400 mb-8">Choose which in-app notifications you receive.</p>
 
-    <div id="status" class="hidden mb-4 p-3 rounded-lg text-sm"></div>
+    <div id="status" class="hidden mb-4 p-3 rounded-lg text-sm" role="status" aria-live="polite"></div>
 
     <form id="prefs-form" class="space-y-6 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-6 shadow-md">
       <label class="flex items-center justify-between gap-4 cursor-pointer">
@@ -64,7 +64,7 @@
   <script>
     const API = '';
     const token = localStorage.getItem('edu_token');
-    const esc = window.esc || (s => String(s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;'));
+    const esc = window.esc || (s => String(s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'));
 
     if (!token) window.location.href = '/login.html';
 
@@ -100,20 +100,24 @@
         session_notify: document.getElementById('session_notify').checked,
         system_notify: document.getElementById('system_notify').checked,
       };
-      const res = await fetch(`${API}/api/notification-preferences`, {
-        method: 'PATCH',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(payload),
-      });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        showStatus(err.error || 'Save failed', false);
-        return;
+      try {
+        const res = await fetch(`${API}/api/notification-preferences`, {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          showStatus(err.error || 'Save failed', false);
+          return;
+        }
+        showStatus('Preferences saved.', true);
+      } catch (err) {
+        showStatus(err.message || 'Network error — please try again', false);
       }
-      showStatus('Preferences saved.', true);
     });
 
     loadPrefs().catch(err => showStatus(esc(err.message), false));

--- a/public/notifications.html
+++ b/public/notifications.html
@@ -1,0 +1,380 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Notifications - Alpha One Labs">
+  <title>Notifications - Alpha One Labs</title>
+  <link rel="icon" type="image/png" href="https://alphaonelabs.com/static/images/logo.png" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+  <script>
+    tailwind.config = { darkMode: 'class', theme: { extend: {} } };
+    (function () {
+      if (localStorage.getItem('darkMode') === 'true') document.documentElement.classList.add('dark');
+    })();
+  </script>
+</head>
+<body class="min-h-screen flex flex-col bg-white text-gray-900 dark:bg-black dark:text-gray-100 transition-colors duration-300 overflow-x-hidden">
+
+  <div id="site-navbar"></div>
+
+  <section class="border-b border-gray-200 dark:border-gray-800 bg-white/70 dark:bg-black/40 backdrop-blur">
+    <div class="max-w-3xl mx-auto px-4 py-5 flex items-center justify-between gap-4">
+      <div>
+        
+        <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 flex items-center gap-3 flex-wrap">
+          <i class="fas fa-bell text-teal-600 dark:text-teal-400"></i> Notifications
+          <span id="header-unread" class="hidden text-xs font-semibold bg-red-500 text-white px-2 py-0.5 rounded-full"></span>
+        </h1>
+       
+      </div>
+      <a href="/notification-preferences.html"
+        class="shrink-0 hidden sm:inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800">
+        <i class="fas fa-sliders-h"></i> Preferences
+      </a>
+    </div>
+  </section>
+
+  <main class="flex-1 max-w-3xl w-full mx-auto px-4 py-6">
+    <div class="flex flex-wrap items-center justify-between gap-3 mb-5">
+      <div class="flex gap-2">
+        <button id="filter-all" type="button" onclick="setFilter(false)"
+          class="px-4 py-2 rounded-lg text-sm font-semibold bg-teal-600 text-white">All</button>
+        <button id="filter-unread" type="button" onclick="setFilter(true)"
+          class="px-4 py-2 rounded-lg text-sm font-semibold bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200">Unread</button>
+      </div>
+      <div class="flex gap-2 flex-wrap">
+        <a href="/notification-preferences.html"
+          class="sm:hidden px-4 py-2 rounded-lg text-sm font-medium border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800">
+          <i class="fas fa-sliders-h mr-1"></i> Preferences
+        </a>
+        <button type="button" onclick="markAllRead()"
+          class="px-4 py-2 rounded-lg text-sm font-semibold bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-900 hover:opacity-90">
+          Mark all read
+        </button>
+      </div>
+    </div>
+
+    <div id="notif-list" class="space-y-3">
+      <div class="animate-pulse rounded-xl h-20 bg-gray-200 dark:bg-gray-800"></div>
+    </div>
+
+    <div id="load-more-wrap" class="hidden mt-6 text-center">
+      <button type="button" onclick="loadMore()"
+        class="px-6 py-2 rounded-lg border border-teal-500 text-teal-600 dark:text-teal-400 font-semibold hover:bg-teal-50 dark:hover:bg-teal-900/30">
+        Load more
+      </button>
+    </div>
+  </main>
+
+  <div id="site-footer"></div>
+
+  <script src="/js/layout.js" defer></script>
+  <script>
+    const API = '';
+    const token = localStorage.getItem('edu_token');
+    const user = JSON.parse(localStorage.getItem('edu_user') || 'null');
+    const esc = window.esc || (s => String(s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'));
+    const cssEscape = window.CSS && window.CSS.escape
+      ? window.CSS.escape
+      : (s) => String(s || '').replace(/["\\]/g, '\\$&');
+
+    if (!token || !user) window.location.href = '/login.html';
+    let unreadOnly = false;
+    let offset = 0;
+    const limit = 20;
+    let hasMore = true;
+    let refreshTimer = null;
+    let isRefreshing = false;
+    const CACHE_KEY = 'notif_cache_v1';
+    const CACHE_TTL_MS = 30000;
+
+    const typeStyle = {
+      info:    'border-l-blue-500 bg-blue-50/50 dark:bg-blue-900/20',
+      success: 'border-l-green-500 bg-green-50/50 dark:bg-green-900/20',
+      warning: 'border-l-amber-500 bg-amber-50/50 dark:bg-amber-900/20',
+      error:   'border-l-red-500 bg-red-50/50 dark:bg-red-900/20',
+    };
+
+    const typeLabel = {
+      info: 'Info',
+      success: 'Success',
+      warning: 'Warning',
+      error: 'Alert',
+    };
+
+    const typeBadge = {
+      info: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-200',
+      success: 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-200',
+      warning: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-200',
+      error: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-200',
+    };
+
+    function setFilter(unread) {
+      unreadOnly = unread;
+      offset = 0;
+      hasMore = true;
+      document.getElementById('filter-all').className = unread
+        ? 'px-4 py-2 rounded-lg text-sm font-semibold bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200'
+        : 'px-4 py-2 rounded-lg text-sm font-semibold bg-teal-600 text-white';
+      document.getElementById('filter-unread').className = unread
+        ? 'px-4 py-2 rounded-lg text-sm font-semibold bg-teal-600 text-white'
+        : 'px-4 py-2 rounded-lg text-sm font-semibold bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200';
+      loadNotifications(true);
+    }
+
+    function formatWhen(iso) {
+      if (!iso) return '';
+      const d = new Date(iso.includes('T') ? iso : iso.replace(' ', 'T') + 'Z');
+      if (Number.isNaN(d.getTime())) return esc(iso);
+      return d.toLocaleString();
+    }
+
+    function renderItem(n) {
+      const style = typeStyle[n.type] || typeStyle.info;
+      const badge = typeBadge[n.type] || typeBadge.info;
+      const label = typeLabel[n.type] || 'Info';
+      const unread = !n.is_read;
+      const safeId = esc(n.id);
+      return `
+        <article class="rounded-xl border border-gray-200 dark:border-gray-700 border-l-4 ${style} p-4 ${unread ? 'ring-1 ring-teal-500/30' : 'opacity-90'}"
+          data-id="${safeId}" data-read="${unread ? '0' : '1'}">
+          <div class="flex justify-between gap-3 items-start">
+            <div class="min-w-0 flex-1">
+              <div class="flex items-center gap-2 flex-wrap">
+                <span class="text-[11px] font-semibold px-2 py-0.5 rounded-full ${badge}">${label}</span>
+                <h2 class="font-semibold text-gray-900 dark:text-gray-100">${esc(n.title)}</h2>
+              </div>
+              <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">${esc(n.message)}</p>
+              <p class="text-xs text-gray-500 mt-2">${formatWhen(n.created_at)}</p>
+            </div>
+            ${unread ? `<button type="button" data-mark-read="${safeId}"
+              class="shrink-0 text-xs font-semibold text-teal-600 dark:text-teal-400 hover:underline">Mark read</button>` : ''}
+          </div>
+        </article>`;
+    }
+
+    document.getElementById('notif-list').addEventListener('click', (e) => {
+      const btn = e.target.closest('[data-mark-read]');
+      if (btn) markRead(btn.getAttribute('data-mark-read'));
+    });
+
+    function renderEmpty(list) {
+      list.innerHTML = `
+        <div class="text-center py-16 text-gray-500 dark:text-gray-400">
+          <i class="fas fa-bell-slash text-4xl mb-3 block opacity-50"></i>
+          <p class="font-medium">${unreadOnly ? 'No unread notifications' : 'No notifications yet'}</p>
+        </div>`;
+    }
+
+    function readCache() {
+      try {
+        const raw = localStorage.getItem(CACHE_KEY);
+        if (!raw) return null;
+        const data = JSON.parse(raw);
+        if (!data || !Array.isArray(data.items)) return null;
+        if (Date.now() - data.ts > CACHE_TTL_MS) return null;
+        return data;
+      } catch (_) {
+        return null;
+      }
+    }
+
+    function writeCache(items, unread) {
+      try {
+        localStorage.setItem(CACHE_KEY, JSON.stringify({ ts: Date.now(), items, unread }));
+      } catch (_) {
+        /* ignore */
+      }
+    }
+
+    async function fetchNotifications({ pageOffset = offset, pageLimit = limit } = {}) {
+      const q = new URLSearchParams({ limit: String(pageLimit), offset: String(pageOffset) });
+      if (unreadOnly) q.set('unread_only', 'true');
+      const res = await fetch(`${API}/api/notifications?${q}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.status === 401) {
+        localStorage.removeItem('edu_token');
+        localStorage.removeItem('edu_user');
+        window.location.href = '/login.html';
+        return null;
+      }
+      if (!res.ok) throw new Error('Failed to load notifications');
+      const body = await res.json();
+      const data = body.data || {};
+      return {
+        items: data.notifications || [],
+        unread: data.unread_count ?? 0,
+      };
+    }
+
+    async function loadNotifications(replace) {
+      if (isRefreshing) return;
+      isRefreshing = true;
+      const list = document.getElementById('notif-list');
+      if (replace) {
+        const cached = !unreadOnly && offset === 0 ? readCache() : null;
+        if (cached && cached.items.length) {
+          list.innerHTML = cached.items.map(renderItem).join('');
+          updateHeaderUnread(cached.unread ?? 0);
+        } else {
+          list.innerHTML = '<div class="animate-pulse rounded-xl h-20 bg-gray-200 dark:bg-gray-800"></div>';
+        }
+      }
+      try {
+        const result = await fetchNotifications();
+        if (!result) return;
+        const { items, unread } = result;
+
+        updateHeaderUnread(unread);
+        if (window.refreshUnreadBadge) window.refreshUnreadBadge();
+
+        if (replace) {
+          if (!items.length) {
+            renderEmpty(list);
+          } else {
+            list.innerHTML = items.map(renderItem).join('');
+          }
+          if (!unreadOnly && offset === 0) writeCache(items, unread);
+        } else if (items.length) {
+          list.insertAdjacentHTML('beforeend', items.map(renderItem).join(''));
+        }
+
+        hasMore = items.length >= limit;
+        document.getElementById('load-more-wrap').classList.toggle('hidden', !hasMore);
+      } catch (e) {
+        list.innerHTML = `<p class="text-red-600 dark:text-red-400 text-center py-8">${esc(e.message)}</p>`;
+      } finally {
+        isRefreshing = false;
+      }
+    }
+
+    function updateHeaderUnread(unread) {
+      const badge = document.getElementById('header-unread');
+      if (!badge) return;
+      if (unread > 0) {
+        badge.textContent = `${unread} unread`;
+        badge.classList.remove('hidden');
+      } else {
+        badge.classList.add('hidden');
+      }
+    }
+
+    let headerUnreadPollTimer = null;
+
+    async function pollUnreadCount() {
+      try {
+        const res = await fetch(`${API}/api/notifications/unread-count`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) return;
+        const body = await res.json();
+        const unread = (body.data && body.data.unread_count) || 0;
+        updateHeaderUnread(unread);
+        if (window.refreshUnreadBadge) window.refreshUnreadBadge();
+      } catch (_) {
+        /* ignore */
+      }
+    }
+
+    function startHeaderUnreadPolling() {
+      if (headerUnreadPollTimer) return;
+      headerUnreadPollTimer = setInterval(pollUnreadCount, 5000);
+      pollUnreadCount();
+    }
+
+    async function silentRefresh() {
+      if (isRefreshing) return;
+      const list = document.getElementById('notif-list');
+      const currentScroll = window.scrollY;
+      const beforeHeight = list.scrollHeight;
+      try {
+        const result = await fetchNotifications({ pageOffset: 0, pageLimit: limit });
+        if (!result) return;
+        const { items, unread } = result;
+        updateHeaderUnread(unread);
+        if (window.refreshUnreadBadge) window.refreshUnreadBadge();
+
+        if (!items.length) {
+          if (!list.querySelector('[data-id]')) {
+            renderEmpty(list);
+          }
+          return;
+        }
+
+        const newItems = [];
+        items.forEach((n) => {
+          const id = String(n.id);
+          const existing = list.querySelector(`[data-id="${cssEscape(id)}"]`);
+          if (!existing) {
+            newItems.push(renderItem(n));
+          } else if (existing.getAttribute('data-read') !== (n.is_read ? '1' : '0')) {
+            existing.outerHTML = renderItem(n);
+          }
+        });
+
+        if (newItems.length) {
+          list.insertAdjacentHTML('afterbegin', newItems.join(''));
+          const afterHeight = list.scrollHeight;
+          const delta = afterHeight - beforeHeight;
+          window.scrollTo(0, currentScroll + delta);
+        }
+
+        hasMore = items.length >= limit;
+        document.getElementById('load-more-wrap').classList.toggle('hidden', !hasMore);
+      } catch (_) {
+        /* silent */
+      }
+    }
+
+    function startListPolling() {
+      if (refreshTimer) return;
+      refreshTimer = setInterval(() => {
+        silentRefresh();
+      }, 8000);
+    }
+
+    function loadMore() {
+      offset += limit;
+      loadNotifications(false);
+    }
+
+    async function markRead(id) {
+      const res = await fetch(`${API}/api/notifications/${encodeURIComponent(id)}/read`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        offset = 0;
+        loadNotifications(true);
+        pollUnreadCount();
+      }
+    }
+
+    async function markAllRead() {
+      const res = await fetch(`${API}/api/notifications/read-all`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        offset = 0;
+        loadNotifications(true);
+        pollUnreadCount();
+      }
+    }
+
+    async function initPage() {
+      loadNotifications(true);
+      startHeaderUnreadPolling();
+      startListPolling();
+      if (window.initLayout) await window.initLayout();
+      if (window.updateAuthSection) window.updateAuthSection();
+      if (window.refreshUnreadBadge) window.refreshUnreadBadge();
+    }
+
+    document.addEventListener('DOMContentLoaded', initPage);
+  </script>
+</body>
+</html>

--- a/public/notifications.html
+++ b/public/notifications.html
@@ -39,9 +39,9 @@
   <main class="flex-1 max-w-3xl w-full mx-auto px-4 py-6">
     <div class="flex flex-wrap items-center justify-between gap-3 mb-5">
       <div class="flex gap-2">
-        <button id="filter-all" type="button" onclick="setFilter(false)"
+        <button id="filter-all" type="button" onclick="setFilter(false)" aria-pressed="true"
           class="px-4 py-2 rounded-lg text-sm font-semibold bg-teal-600 text-white">All</button>
-        <button id="filter-unread" type="button" onclick="setFilter(true)"
+        <button id="filter-unread" type="button" onclick="setFilter(true)" aria-pressed="false"
           class="px-4 py-2 rounded-lg text-sm font-semibold bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200">Unread</button>
       </div>
       <div class="flex gap-2 flex-wrap">
@@ -87,7 +87,7 @@
     let hasMore = true;
     let refreshTimer = null;
     let isRefreshing = false;
-    const CACHE_KEY = 'notif_cache_v1';
+    const CACHE_KEY = `notif_cache_v1_${user.id || 'anon'}`;
     const CACHE_TTL_MS = 30000;
 
     const typeStyle = {
@@ -121,7 +121,14 @@
       document.getElementById('filter-unread').className = unread
         ? 'px-4 py-2 rounded-lg text-sm font-semibold bg-teal-600 text-white'
         : 'px-4 py-2 rounded-lg text-sm font-semibold bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200';
+      document.getElementById('filter-all').setAttribute('aria-pressed', unread ? 'false' : 'true');
+      document.getElementById('filter-unread').setAttribute('aria-pressed', unread ? 'true' : 'false');
       loadNotifications(true);
+    }
+
+    function syncUnreadBadges(unread) {
+      updateHeaderUnread(unread);
+      if (window.applyUnreadBadgeCount) window.applyUnreadBadgeCount(unread);
     }
 
     function formatWhen(iso) {
@@ -218,7 +225,7 @@
         const cached = !unreadOnly && offset === 0 ? readCache() : null;
         if (cached && cached.items.length) {
           list.innerHTML = cached.items.map(renderItem).join('');
-          updateHeaderUnread(cached.unread ?? 0);
+          syncUnreadBadges(cached.unread ?? 0);
         } else {
           list.innerHTML = '<div class="animate-pulse rounded-xl h-20 bg-gray-200 dark:bg-gray-800"></div>';
         }
@@ -228,8 +235,7 @@
         if (!result) return;
         const { items, unread } = result;
 
-        updateHeaderUnread(unread);
-        if (window.refreshUnreadBadge) window.refreshUnreadBadge();
+        syncUnreadBadges(unread);
 
         if (replace) {
           if (!items.length) {
@@ -240,6 +246,8 @@
           if (!unreadOnly && offset === 0) writeCache(items, unread);
         } else if (items.length) {
           list.insertAdjacentHTML('beforeend', items.map(renderItem).join(''));
+        } else {
+          hasMore = false;
         }
 
         hasMore = items.length >= limit;
@@ -262,29 +270,6 @@
       }
     }
 
-    let headerUnreadPollTimer = null;
-
-    async function pollUnreadCount() {
-      try {
-        const res = await fetch(`${API}/api/notifications/unread-count`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-        if (!res.ok) return;
-        const body = await res.json();
-        const unread = (body.data && body.data.unread_count) || 0;
-        updateHeaderUnread(unread);
-        if (window.refreshUnreadBadge) window.refreshUnreadBadge();
-      } catch (_) {
-        /* ignore */
-      }
-    }
-
-    function startHeaderUnreadPolling() {
-      if (headerUnreadPollTimer) return;
-      headerUnreadPollTimer = setInterval(pollUnreadCount, 5000);
-      pollUnreadCount();
-    }
-
     async function silentRefresh() {
       if (isRefreshing) return;
       const list = document.getElementById('notif-list');
@@ -294,8 +279,7 @@
         const result = await fetchNotifications({ pageOffset: 0, pageLimit: limit });
         if (!result) return;
         const { items, unread } = result;
-        updateHeaderUnread(unread);
-        if (window.refreshUnreadBadge) window.refreshUnreadBadge();
+        syncUnreadBadges(unread);
 
         if (!items.length) {
           if (!list.querySelector('[data-id]')) {
@@ -332,13 +316,40 @@
     function startListPolling() {
       if (refreshTimer) return;
       refreshTimer = setInterval(() => {
-        silentRefresh();
-      }, 8000);
+        if (!document.hidden) {
+          silentRefresh();
+        }
+      }, 10000);
     }
 
-    function loadMore() {
-      offset += limit;
-      loadNotifications(false);
+    function stopListPolling() {
+      if (!refreshTimer) return;
+      clearInterval(refreshTimer);
+      refreshTimer = null;
+    }
+
+    async function loadMore() {
+      if (!hasMore || isRefreshing) return;
+      const nextOffset = offset + limit;
+      isRefreshing = true;
+      try {
+        const result = await fetchNotifications({ pageOffset: nextOffset, pageLimit: limit });
+        if (!result) return;
+        const list = document.getElementById('notif-list');
+        const { items } = result;
+        if (items.length) {
+          list.insertAdjacentHTML('beforeend', items.map(renderItem).join(''));
+          offset = nextOffset;
+        }
+        hasMore = items.length >= limit;
+        document.getElementById('load-more-wrap').classList.toggle('hidden', !hasMore);
+      } catch (e) {
+        const list = document.getElementById('notif-list');
+        list.insertAdjacentHTML('beforeend',
+          `<p class="text-red-600 dark:text-red-400 text-center py-4">${esc(e.message)}</p>`);
+      } finally {
+        isRefreshing = false;
+      }
     }
 
     async function markRead(id) {
@@ -349,7 +360,6 @@
       if (res.ok) {
         offset = 0;
         loadNotifications(true);
-        pollUnreadCount();
       }
     }
 
@@ -361,18 +371,23 @@
       if (res.ok) {
         offset = 0;
         loadNotifications(true);
-        pollUnreadCount();
       }
     }
 
     async function initPage() {
       loadNotifications(true);
-      startHeaderUnreadPolling();
       startListPolling();
       if (window.initLayout) await window.initLayout();
-      if (window.updateAuthSection) window.updateAuthSection();
-      if (window.refreshUnreadBadge) window.refreshUnreadBadge();
     }
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        stopListPolling();
+      } else {
+        startListPolling();
+        silentRefresh();
+      }
+    });
 
     document.addEventListener('DOMContentLoaded', initPage);
   </script>

--- a/public/partials/navbar.html
+++ b/public/partials/navbar.html
@@ -179,8 +179,9 @@
                 </a>
 
                 <!-- Notification Button -->
-                <a href="#" class="relative hover:underline flex items-center p-2 hover:bg-teal-700 rounded-lg">
+                <a href="/notifications.html" id="notif-bell-link" class="relative hover:underline flex items-center p-2 hover:bg-teal-700 rounded-lg" title="Notifications">
                     <i class="fas fa-bell"></i>
+                    <span id="notif-unread-badge" class="hidden absolute -top-1 -right-1 min-w-[1rem] h-4 px-1 rounded-full bg-red-600 flex items-center justify-center text-white text-xs font-bold"></span>
                 </a>
 
                 <!-- Language Dropdown -->
@@ -239,9 +240,8 @@
                                 <i class="fas fa-chart-line mr-2 text-teal-500"></i>
                                 <span>Dashboard</span>
                             </a>
-                            <a href="/" class="flex items-center px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-teal-50 dark:hover:bg-teal-900 hover:text-teal-600 dark:hover:text-teal-300">
-                                <i class="fas fa-cog mr-2 text-teal-500"></i>
-                                <span>Settings</span>
+                            <a href="/notifications.html" class="flex items-center py-2 px-3 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md">
+                                <i class="fas fa-bell mr-2 text-teal-500"></i><span>Notifications</span>
                             </a>
                             <hr class="border-gray-200 dark:border-gray-700 my-1">
                             <button onclick="logout()" class="w-full text-left flex items-center px-4 py-2 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20">
@@ -306,8 +306,8 @@
                             <a href="/dashboard.html" class="flex items-center py-2 px-3 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md">
                                 <i class="fas fa-chart-line mr-2 text-teal-500"></i><span>Dashboard</span>
                             </a>
-                            <a href="/settings.html" class="flex items-center py-2 px-3 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md">
-                                <i class="fas fa-cog mr-2 text-teal-500"></i><span>Settings</span>
+                            <a href="/notifications.html" class="flex items-center py-2 px-3 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md">
+                                <i class="fas fa-bell mr-2 text-teal-500"></i><span>Notifications</span>
                             </a>
                             <button onclick="logout()" class="w-full flex items-center py-2 px-3 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-md mt-2">
                                 <i class="fas fa-sign-out-alt mr-2"></i><span>Logout</span>

--- a/public/partials/navbar.html
+++ b/public/partials/navbar.html
@@ -179,7 +179,7 @@
                 </a>
 
                 <!-- Notification Button -->
-                <a href="/notifications.html" id="notif-bell-link" class="relative hover:underline flex items-center p-2 hover:bg-teal-700 rounded-lg" title="Notifications">
+                <a href="/notifications.html" id="notif-bell-link" class="relative hover:underline flex items-center p-2 hover:bg-teal-700 rounded-lg" aria-label="Notifications" title="Notifications">
                     <i class="fas fa-bell"></i>
                     <span id="notif-unread-badge" class="hidden absolute -top-1 -right-1 min-w-[1rem] h-4 px-1 rounded-full bg-red-600 flex items-center justify-center text-white text-xs font-bold"></span>
                 </a>
@@ -239,9 +239,6 @@
                             <a href="/dashboard.html" class="flex items-center px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-teal-50 dark:hover:bg-teal-900 hover:text-teal-600 dark:hover:text-teal-300">
                                 <i class="fas fa-chart-line mr-2 text-teal-500"></i>
                                 <span>Dashboard</span>
-                            </a>
-                            <a href="/notifications.html" class="flex items-center py-2 px-3 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md">
-                                <i class="fas fa-bell mr-2 text-teal-500"></i><span>Notifications</span>
                             </a>
                             <hr class="border-gray-200 dark:border-gray-700 my-1">
                             <button onclick="logout()" class="w-full text-left flex items-center px-4 py-2 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20">

--- a/schema.sql
+++ b/schema.sql
@@ -109,3 +109,13 @@ CREATE TABLE IF NOT EXISTS notifications (
 CREATE INDEX IF NOT EXISTS idx_notif_user   ON notifications(user_id);
 CREATE INDEX IF NOT EXISTS idx_notif_unread  ON notifications(user_id, is_read);
 CREATE INDEX IF NOT EXISTS idx_notif_created ON notifications(user_id, created_at DESC);
+
+-- NOTIFICATION PREFERENCES
+CREATE TABLE IF NOT EXISTS notification_preferences (
+    user_id           TEXT PRIMARY KEY,
+    enrollment_notify INTEGER NOT NULL DEFAULT 1,
+    session_notify    INTEGER NOT NULL DEFAULT 1,
+    system_notify     INTEGER NOT NULL DEFAULT 1,
+    updated_at        TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/src/worker.py
+++ b/src/worker.py
@@ -243,6 +243,32 @@ async def decrypt_aes(ciphertext: str, secret: str) -> str:
         return "[decryption error]"
 
 
+async def decrypt_aes_with_key(ciphertext: str, crypto_key: object, secret: str) -> str:
+    """
+    AES-256-GCM decryption using a pre-imported CryptoKey.
+    Handles both v1 (AES-GCM) and legacy (XOR) ciphertext.
+    """
+    if not ciphertext:
+        return ""
+    if not ciphertext.startswith("v1:"):
+        return _decrypt_xor(ciphertext, secret)
+    try:
+        raw = base64.b64decode(ciphertext[3:])
+        iv, ct = raw[:12], raw[12:]
+    except Exception as exc:
+        await capture_exception(exc, where="decrypt_aes_with_key.decode")
+        return "[decryption error]"
+    try:
+        iv_array = to_js(iv, create_pyproxies=False)
+        algo = to_js({"name": "AES-GCM", "iv": iv_array}, dict_converter=js.Object.fromEntries)
+        data = to_js(ct, create_pyproxies=False)
+        pt_buf = await js.crypto.subtle.decrypt(algo, crypto_key, data)
+        return bytes(js.Uint8Array.new(pt_buf)).decode("utf-8")
+    except Exception as exc:
+        await capture_exception(exc, where="decrypt_aes_with_key.auth")
+        return "[decryption error]"
+
+
 def _encrypt_xor(plaintext: str, secret: str) -> str:
     """Legacy XOR stream cipher — kept for backward compatibility only."""
     if not plaintext:
@@ -357,7 +383,7 @@ def verify_token(raw: str, secret: str):
 
 _CORS = {
     "Access-Control-Allow-Origin":  "*",
-    "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+    "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type, Authorization",
 }
 
@@ -538,7 +564,15 @@ _DDL = [
     "CREATE INDEX IF NOT EXISTS idx_notif_user   ON notifications(user_id)",
     "CREATE INDEX IF NOT EXISTS idx_notif_unread  ON notifications(user_id, is_read)",
     "CREATE INDEX IF NOT EXISTS idx_notif_created ON notifications(user_id, created_at DESC)",
-
+    # Notification preferences
+    """CREATE TABLE IF NOT EXISTS notification_preferences (
+        user_id           TEXT PRIMARY KEY,
+        enrollment_notify INTEGER NOT NULL DEFAULT 1,
+        session_notify    INTEGER NOT NULL DEFAULT 1,
+        system_notify     INTEGER NOT NULL DEFAULT 1,
+        updated_at        TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    )""",
 ]
 
 
@@ -782,6 +816,9 @@ async def api_register(req, env):
         return err("Registration failed — please try again", 500)
 
     token = create_token(uid, username, role, env.JWT_SECRET)
+
+    await _seed_notification_preferences(env, uid)
+
     return ok(
         {"token": token,
          "user": {"id": uid, "username": username, "name": name, "role": role}},
@@ -987,6 +1024,10 @@ async def api_create_activity(req, env):
             await capture_exception(e, req, env, f"api_create_activity.insert_activity_tags: tag_name={tag_name}, tag_id={tag_id}, act_id={act_id}")
             pass
 
+    await emit_event(env, "ACTIVITY_CREATED", {
+        "user_id": user["id"], "activity_id": act_id, "title": title,
+    })
+
     return ok({"id": act_id, "title": title}, "Activity created")
 
 
@@ -1080,20 +1121,59 @@ async def api_join(req, env):
         role = "participant"
 
     act = await env.DB.prepare(
-        "SELECT id FROM activities WHERE id=?"
+        "SELECT id, title, host_id FROM activities WHERE id=?"
     ).bind(act_id).first()
     if not act:
         return err("Activity not found", 404)
 
+    existing = await env.DB.prepare(
+        "SELECT id FROM enrollments WHERE activity_id=? AND user_id=?"
+    ).bind(act_id, user["id"]).first()
+    if existing:
+        return ok(None, "Already joined this activity")
+
     enr_id = new_id()
     try:
-        await env.DB.prepare(
-            "INSERT OR IGNORE INTO enrollments (id,activity_id,user_id,role)"
+        insert_res = await env.DB.prepare(
+            "INSERT INTO enrollments (id,activity_id,user_id,role)"
             " VALUES (?,?,?,?)"
         ).bind(enr_id, act_id, user["id"], role).run()
     except Exception as e:
         await capture_exception(e, req, env, "api_join.insert_enrollment")
         return err("Failed to join activity — please try again", 500)
+
+    changes = None
+    try:
+        meta = getattr(insert_res, "meta", None) if insert_res is not None else None
+        if isinstance(meta, dict):
+            changes = meta.get("changes")
+        elif meta is not None:
+            changes = getattr(meta, "changes", None)
+    except Exception:
+        changes = None
+
+    if changes == 0:
+        return ok(None, "Already joined this activity")
+
+    participant_name = user.get("username") or "Participant"
+    try:
+        u_row = await env.DB.prepare(
+            "SELECT name FROM users WHERE id=?"
+        ).bind(user["id"]).first()
+        if u_row and u_row.name:
+            dec_name = await decrypt_aes(u_row.name, env.ENCRYPTION_KEY)
+            if dec_name and dec_name != "[decryption error]":
+                participant_name = dec_name
+    except Exception:
+        pass
+
+    await emit_event(env, "USER_ENROLLED", {
+        "user_id":      user["id"],
+        "host_id":      act.host_id,
+        "activity_id":  act_id,
+        "activity_title": act.title,
+        "participant_name": participant_name,
+    })
 
     return ok(None, "Joined activity successfully")
 
@@ -1205,6 +1285,18 @@ async def api_create_session(req, env):
         await capture_exception(e, req, env, "api_create_session.insert_session")
         return err("Failed to create session — please try again", 500)
 
+    act_row = await env.DB.prepare(
+        "SELECT title FROM activities WHERE id = ?"
+    ).bind(act_id).first()
+    recipient_ids = await _activity_enrollee_ids(env, act_id, exclude_user_id=user["id"])
+    await emit_event(env, "SESSION_CREATED", {
+        "session_id":    sid,
+        "session_title": title,
+        "activity_id":   act_id,
+        "activity_title": act_row.title if act_row else act_id,
+        "recipient_ids": recipient_ids,
+    })
+
     return ok({"id": sid}, "Session created")
 
 
@@ -1261,6 +1353,17 @@ async def api_add_activity_tags(req, env):
             await capture_exception(e, req, env, f"api_add_activity_tags.insert_activity_tags: tag_name={tag_name}, tag_id={tag_id}, act_id={act_id}")
             pass
 
+    act_row = await env.DB.prepare(
+        "SELECT title FROM activities WHERE id=?"
+    ).bind(act_id).first()
+    recipient_ids = await _activity_enrollee_ids(env, act_id, exclude_user_id=user["id"])
+    if recipient_ids:
+        await emit_event(env, "ACTIVITY_TAGS_UPDATED", {
+            "activity_id":    act_id,
+            "activity_title": act_row.title if act_row else act_id,
+            "recipient_ids":  recipient_ids,
+        })
+
     return ok(None, "Tags updated")
 
 
@@ -1309,6 +1412,12 @@ _MIME = {
 }
 
 
+def _static_cache_control(ext: str) -> str:
+    if ext in {"html", "json"}:
+        return "public, max-age=60, s-maxage=300"
+    return "public, max-age=86400, s-maxage=604800, immutable"
+
+
 async def serve_static(path: str, env):
     if path in ("/", ""):
         key = "index.html"
@@ -1337,7 +1446,14 @@ async def serve_static(path: str, env):
 
     ext  = key.rsplit(".", 1)[-1] if "." in key else "html"
     mime = _MIME.get(ext, "text/plain")
-    return Response(content, headers={"Content-Type": mime, **_CORS})
+    return Response(
+        content,
+        headers={
+            "Content-Type": mime,
+            "Cache-Control": _static_cache_control(ext),
+            **_CORS,
+        },
+    )
 
 class ClassroomDO(DurableObject):
     """WebSocket based virtual classroom Durable Object.
@@ -2128,6 +2244,12 @@ async def _dispatch(request, env):
         if path == "/api/notifications/read-all" and method == "POST":
             return await api_mark_all_read(request, env)
 
+        # Notification Preferences
+        if path == "/api/notification-preferences" and method == "GET":
+            return await api_get_notification_preferences(request, env)
+        if path == "/api/notification-preferences" and method == "PATCH":
+            return await api_patch_notification_preferences(request, env)
+
         return err("API endpoint not found", 404)
 
     return await serve_static(path, env)
@@ -2146,23 +2268,145 @@ async def on_fetch(request, env):
 # Notifications API
 # ---------------------------------------------------------------------------
 
+# Notification category → preference column mapping
+_NOTIF_PREF_MAP = {
+    "enrollment": "enrollment_notify",
+    "session":    "session_notify",
+    "system":     "system_notify",
+}
+
+_EVENT_HANDLERS = {}
+
+
+def _event_handler(name: str):
+    def decorator(fn):
+        _EVENT_HANDLERS[name] = fn
+        return fn
+    return decorator
+
+
+async def _seed_notification_preferences(env, user_id: str) -> None:
+    try:
+        await env.DB.prepare(
+            "INSERT OR IGNORE INTO notification_preferences (user_id) VALUES (?)"
+        ).bind(user_id).run()
+    except Exception:
+        pass
+
+
+async def _activity_enrollee_ids(env, activity_id: str,
+                                 exclude_user_id: Optional[str] = None) -> list:
+    rows = await env.DB.prepare(
+        "SELECT user_id FROM enrollments"
+        " WHERE activity_id = ? AND status = 'active'"
+    ).bind(activity_id).all()
+    ids = [r.user_id for r in (rows.results or [])]
+    if exclude_user_id:
+        ids = [uid for uid in ids if uid != exclude_user_id]
+    return ids
+
+
+async def emit_event(env, event: str, payload: dict) -> None:
+    """Dispatch a domain event to registered notification handlers."""
+    handler = _EVENT_HANDLERS.get(event)
+    if handler:
+        try:
+            await handler(env, payload)
+        except Exception as exc:
+            print(f"[emit_event ERROR] {event}: {type(exc).__name__}: {exc}")
+
+
+@_event_handler("USER_ENROLLED")
+async def _on_user_enrolled(env, p: dict) -> None:
+    title = p["activity_title"]
+    act_id = p["activity_id"]
+    await _create_notification(
+        env, p["user_id"], "success", "Enrollment Confirmed",
+        f"You have joined '{title}'.",
+        related_id=act_id, category="enrollment",
+    )
+    host_id = p.get("host_id")
+    if host_id and host_id != p["user_id"]:
+        joiner = p.get("participant_name") or "A new participant"
+        await _create_notification(
+            env, host_id, "info", "New Participant",
+            f"{joiner} joined '{title}'.",
+            related_id=act_id, category="enrollment",
+        )
+
+
+@_event_handler("SESSION_CREATED")
+async def _on_session_created(env, p: dict) -> None:
+    for uid in p.get("recipient_ids") or []:
+        await _create_notification(
+            env, uid, "info", f"New Session: {p['session_title']}",
+            f"A new session was added to '{p['activity_title']}'.",
+            related_id=p["session_id"], category="session",
+        )
+
+
+@_event_handler("ACTIVITY_CREATED")
+async def _on_activity_created(env, p: dict) -> None:
+    await _create_notification(
+        env, p["user_id"], "success", "Activity Published",
+        f"Your activity '{p['title']}' is now live.",
+        related_id=p["activity_id"], category="system",
+    )
+
+
+@_event_handler("ACTIVITY_TAGS_UPDATED")
+async def _on_activity_tags_updated(env, p: dict) -> None:
+    for uid in p.get("recipient_ids") or []:
+        await _create_notification(
+            env, uid, "info", f"Activity Updated: {p['activity_title']}",
+            f"New tags were added to '{p['activity_title']}'.",
+            related_id=p["activity_id"], category="enrollment",
+        )
+
+
 async def _create_notification(env, user_id: str, type_: str, title: str,
-                                message: str, related_id: Optional[str] = None) -> None:
+                                message: str, related_id: Optional[str] = None,
+                                category: str = "system") -> None:
     """Internal helper called by other handlers to create a notification.
 
-    Silently swallows errors so a notification failure never breaks the
-    parent operation (e.g. grading, peer requests, new assignments).
+    Respects user notification preferences.  Silently swallows errors so a
+    notification failure never breaks the parent operation.
     """
     try:
+        # Check user preferences (default: all enabled)
+        pref_col = _NOTIF_PREF_MAP.get(category, "system_notify")
+        try:
+            pref = await env.DB.prepare(
+                f"SELECT {pref_col} AS enabled FROM notification_preferences"
+                " WHERE user_id = ?"
+            ).bind(user_id).first()
+            if pref and not pref.enabled:
+                return  # user opted out of this category
+        except Exception:
+            pass  # table may not exist yet; default to enabled
+
         enc = env.ENCRYPTION_KEY
         await env.DB.prepare(
             "INSERT INTO notifications (id, user_id, type, title, message, related_id)"
             " VALUES (?, ?, ?, ?, ?, ?)"
         ).bind(new_id(), user_id, type_,
-               encrypt(title, enc), encrypt(message, enc),
+               await encrypt_aes(title, enc),
+               await encrypt_aes(message, enc),
                related_id).run()
     except Exception as exc:
-        await capture_exception(exc, env=env, where="_create_notification")
+        print(f"[_create_notification ERROR] {type(exc).__name__}: {exc}")
+        return f"{type(exc).__name__}: {exc}"
+    return None
+
+
+def _query_int(params: dict, key: str, default: int, min_val: int, max_val: int) -> int:
+    raw = (params.get(key) or [None])[0]
+    if raw is None:
+        return default
+    try:
+        return max(min_val, min(int(raw), max_val))
+    except (ValueError, TypeError):
+        return default
 
 
 async def api_list_notifications(req, env):
@@ -2171,46 +2415,47 @@ async def api_list_notifications(req, env):
     Query params:
       - unread_only=true   return only unread notifications (default: false)
       - limit=N            max results, default 20, max 50
+      - offset=N           skip N rows for pagination (default 0)
     """
     user = verify_token(req.headers.get("Authorization"), env.JWT_SECRET)
     if not user:
         return err("Authentication required", 401)
 
-    url = req.url
-    unread_only = "unread_only=true" in url
-    try:
-        raw_limit = int(url.split("limit=")[1].split("&")[0]) if "limit=" in url else 20
-        limit = max(1, min(raw_limit, 50))
-    except (ValueError, IndexError):
-        limit = 20
+    parsed = urlparse(req.url)
+    params = parse_qs(parsed.query)
+    unread_only = (params.get("unread_only") or [""])[0].lower() == "true"
+    limit  = _query_int(params, "limit",  20, 1, 50)
+    offset = _query_int(params, "offset",  0, 0, 10_000)
 
     if unread_only:
         rows = await env.DB.prepare(
             "SELECT id, type, title, message, is_read, related_id, created_at"
             " FROM notifications"
             " WHERE user_id = ? AND is_read = 0"
-            " ORDER BY created_at DESC LIMIT ?"
-        ).bind(user["id"], limit).all()
+            " ORDER BY created_at DESC LIMIT ? OFFSET ?"
+        ).bind(user["id"], limit, offset).all()
     else:
         rows = await env.DB.prepare(
             "SELECT id, type, title, message, is_read, related_id, created_at"
             " FROM notifications"
             " WHERE user_id = ?"
-            " ORDER BY created_at DESC LIMIT ?"
-        ).bind(user["id"], limit).all()
+            " ORDER BY created_at DESC LIMIT ? OFFSET ?"
+        ).bind(user["id"], limit, offset).all()
 
-    notifications = [
-        {
+    enc = env.ENCRYPTION_KEY
+    key_bytes = _derive_aes_key_bytes(enc)
+    crypto_key = await _import_aes_key(key_bytes)
+    notifications = []
+    for r in rows.results or []:
+        notifications.append({
             "id":         r.id,
             "type":       r.type,
-            "title":      decrypt(r.title or "", env.ENCRYPTION_KEY),
-            "message":    decrypt(r.message or "", env.ENCRYPTION_KEY),
+            "title":      await decrypt_aes_with_key(r.title or "", crypto_key, enc),
+            "message":    await decrypt_aes_with_key(r.message or "", crypto_key, enc),
             "is_read":    bool(r.is_read),
             "related_id": r.related_id,
             "created_at": r.created_at,
-        }
-        for r in rows.results or []
-    ]
+        })
 
     unread_count = await env.DB.prepare(
         "SELECT COUNT(*) AS cnt FROM notifications WHERE user_id = ? AND is_read = 0"
@@ -2219,6 +2464,8 @@ async def api_list_notifications(req, env):
     return ok({
         "notifications": notifications,
         "unread_count":  unread_count.cnt if unread_count else 0,
+        "limit":         limit,
+        "offset":        offset,
     })
 
 
@@ -2266,3 +2513,81 @@ async def api_mark_all_read(req, env):
     ).bind(user["id"]).run()
 
     return ok(msg="All notifications marked as read")
+
+
+async def api_get_notification_preferences(req, env):
+    """GET /api/notification-preferences — return user notification settings."""
+    user = verify_token(req.headers.get("Authorization"), env.JWT_SECRET)
+    if not user:
+        return err("Authentication required", 401)
+
+    row = await env.DB.prepare(
+        "SELECT enrollment_notify, session_notify, system_notify"
+        " FROM notification_preferences WHERE user_id = ?"
+    ).bind(user["id"]).first()
+
+    if not row:
+        return ok({
+            "enrollment_notify": True,
+            "session_notify":    True,
+            "system_notify":     True,
+        })
+
+    return ok({
+        "enrollment_notify": bool(row.enrollment_notify),
+        "session_notify":    bool(row.session_notify),
+        "system_notify":     bool(row.system_notify),
+    })
+
+
+async def api_patch_notification_preferences(req, env):
+    """PATCH /api/notification-preferences — update user notification settings."""
+    user = verify_token(req.headers.get("Authorization"), env.JWT_SECRET)
+    if not user:
+        return err("Authentication required", 401)
+
+    body, bad_resp = await parse_json_object(req)
+    if bad_resp:
+        return bad_resp
+
+    allowed = {"enrollment_notify", "session_notify", "system_notify"}
+    updates = {}
+    for key in allowed:
+        if key in body:
+            val = body[key]
+            if not isinstance(val, bool):
+                return err(f"{key} must be a boolean")
+            updates[key] = 1 if val else 0
+
+    if not updates:
+        return err("No valid fields to update")
+
+    # Read current prefs (or defaults)
+    current = await env.DB.prepare(
+        "SELECT enrollment_notify, session_notify, system_notify"
+        " FROM notification_preferences WHERE user_id = ?"
+    ).bind(user["id"]).first()
+
+    en = updates.get("enrollment_notify",
+                     current.enrollment_notify if current else 1)
+    sn = updates.get("session_notify",
+                     current.session_notify if current else 1)
+    sy = updates.get("system_notify",
+                     current.system_notify if current else 1)
+
+    await env.DB.prepare(
+        "INSERT INTO notification_preferences"
+        " (user_id, enrollment_notify, session_notify, system_notify)"
+        " VALUES (?, ?, ?, ?)"
+        " ON CONFLICT(user_id) DO UPDATE SET"
+        " enrollment_notify = excluded.enrollment_notify,"
+        " session_notify = excluded.session_notify,"
+        " system_notify = excluded.system_notify,"
+        " updated_at = datetime('now')"
+    ).bind(user["id"], en, sn, sy).run()
+
+    return ok({
+        "enrollment_notify": bool(en),
+        "session_notify":    bool(sn),
+        "system_notify":     bool(sy),
+    }, "Preferences updated")

--- a/src/worker.py
+++ b/src/worker.py
@@ -1113,71 +1113,78 @@ async def api_join(req, env):
         return bad_resp
 
     act_id = body.get("activity_id")
-    role   = (body.get("role") or "participant").strip()
+    role = (body.get("role") or "participant").strip()
 
     if not act_id:
         return err("activity_id is required")
+
     if role not in ("participant", "instructor", "organizer"):
         role = "participant"
 
+    # 1️⃣ Get activity
     act = await env.DB.prepare(
         "SELECT id, title, host_id FROM activities WHERE id=?"
     ).bind(act_id).first()
+
     if not act:
         return err("Activity not found", 404)
 
-    existing = await env.DB.prepare(
-        "SELECT id FROM enrollments WHERE activity_id=? AND user_id=?"
-    ).bind(act_id, user["id"]).first()
-    if existing:
-        return ok(None, "Already joined this activity")
+    # ❌ REMOVE existing check completely
 
+    # 2️⃣ Insert enrollment
     enr_id = new_id()
     try:
         insert_res = await env.DB.prepare(
-            "INSERT INTO enrollments (id,activity_id,user_id,role)"
-            " VALUES (?,?,?,?)"
+            "INSERT OR IGNORE INTO enrollments (id,activity_id,user_id,role) VALUES (?,?,?,?)"
         ).bind(enr_id, act_id, user["id"], role).run()
     except Exception as e:
         await capture_exception(e, req, env, "api_join.insert_enrollment")
         return err("Failed to join activity — please try again", 500)
 
+    # 3️⃣ Idempotency via changes
     changes = None
     try:
-        meta = getattr(insert_res, "meta", None) if insert_res is not None else None
+        meta = getattr(insert_res, "meta", None)
         if isinstance(meta, dict):
             changes = meta.get("changes")
         elif meta is not None:
             changes = getattr(meta, "changes", None)
     except Exception:
-        changes = None
+        pass
 
     if changes == 0:
         return ok(None, "Already joined this activity")
 
+    # 4️⃣ Participant name
     participant_name = user.get("username") or "Participant"
+    host_id = getattr(act, "host_id", None)
+
+    if host_id != user["id"]:
+        try:
+            u_row = await env.DB.prepare(
+                "SELECT name FROM users WHERE id=?"
+            ).bind(user["id"]).first()
+
+            if u_row and u_row.name:
+                dec_name = await decrypt_aes(u_row.name, env.ENCRYPTION_KEY)
+                if dec_name and dec_name != "[decryption error]":
+                    participant_name = dec_name
+        except Exception:
+            pass
+
+    # 5️⃣ Emit notification
     try:
-        u_row = await env.DB.prepare(
-            "SELECT name FROM users WHERE id=?"
-        ).bind(user["id"]).first()
-        if u_row and u_row.name:
-            dec_name = await decrypt_aes(u_row.name, env.ENCRYPTION_KEY)
-            if dec_name and dec_name != "[decryption error]":
-                participant_name = dec_name
+        await emit_event(env, "USER_ENROLLED", {
+            "user_id": user["id"],
+            "host_id": host_id,
+            "activity_id": act_id,
+            "activity_title": getattr(act, "title", "Activity"),
+            "participant_name": participant_name,
+        })
     except Exception:
         pass
 
-    await emit_event(env, "USER_ENROLLED", {
-        "user_id":      user["id"],
-        "host_id":      act.host_id,
-        "activity_id":  act_id,
-        "activity_title": act.title,
-        "participant_name": participant_name,
-    })
-
     return ok(None, "Joined activity successfully")
-
-
 async def api_dashboard(req, env):
     user = verify_token(req.headers.get("Authorization"), env.JWT_SECRET)
     if not user:
@@ -1289,6 +1296,7 @@ async def api_create_session(req, env):
         "SELECT title FROM activities WHERE id = ?"
     ).bind(act_id).first()
     recipient_ids = await _activity_enrollee_ids(env, act_id, exclude_user_id=user["id"])
+    
     await emit_event(env, "SESSION_CREATED", {
         "session_id":    sid,
         "session_title": title,
@@ -2306,6 +2314,23 @@ async def _activity_enrollee_ids(env, activity_id: str,
     return ids
 
 
+async def _get_pref_map(env, user_ids: list, pref_col: str) -> Optional[dict]:
+    if not user_ids:
+        return None
+    allowed = {"enrollment_notify", "session_notify", "system_notify"}
+    if pref_col not in allowed:
+        pref_col = "system_notify"
+    placeholders = ",".join(["?"] * len(user_ids))
+    try:
+        rows = await env.DB.prepare(
+            f"SELECT user_id, {pref_col} AS enabled FROM notification_preferences"
+            f" WHERE user_id IN ({placeholders})"
+        ).bind(*user_ids).all()
+        return {r.user_id: bool(r.enabled) for r in (rows.results or [])}
+    except Exception:
+        return None
+
+
 async def emit_event(env, event: str, payload: dict) -> None:
     """Dispatch a domain event to registered notification handlers."""
     handler = _EVENT_HANDLERS.get(event)
@@ -2337,11 +2362,15 @@ async def _on_user_enrolled(env, p: dict) -> None:
 
 @_event_handler("SESSION_CREATED")
 async def _on_session_created(env, p: dict) -> None:
-    for uid in p.get("recipient_ids") or []:
+    recipient_ids = p.get("recipient_ids") or []
+    pref_map = await _get_pref_map(env, recipient_ids, "session_notify")
+    for uid in recipient_ids:
+        if pref_map is not None and pref_map.get(uid) is False:
+            continue
         await _create_notification(
             env, uid, "info", f"New Session: {p['session_title']}",
             f"A new session was added to '{p['activity_title']}'.",
-            related_id=p["session_id"], category="session",
+            related_id=p["session_id"], category="session", skip_pref_check=True,
         )
 
 
@@ -2356,34 +2385,40 @@ async def _on_activity_created(env, p: dict) -> None:
 
 @_event_handler("ACTIVITY_TAGS_UPDATED")
 async def _on_activity_tags_updated(env, p: dict) -> None:
-    for uid in p.get("recipient_ids") or []:
+    recipient_ids = p.get("recipient_ids") or []
+    pref_map = await _get_pref_map(env, recipient_ids, "enrollment_notify")
+    for uid in recipient_ids:
+        if pref_map is not None and pref_map.get(uid) is False:
+            continue
         await _create_notification(
             env, uid, "info", f"Activity Updated: {p['activity_title']}",
             f"New tags were added to '{p['activity_title']}'.",
-            related_id=p["activity_id"], category="enrollment",
+            related_id=p["activity_id"], category="enrollment", skip_pref_check=True,
         )
 
 
 async def _create_notification(env, user_id: str, type_: str, title: str,
                                 message: str, related_id: Optional[str] = None,
-                                category: str = "system") -> None:
+                                category: str = "system",
+                                skip_pref_check: bool = False) -> None:
     """Internal helper called by other handlers to create a notification.
 
     Respects user notification preferences.  Silently swallows errors so a
     notification failure never breaks the parent operation.
     """
     try:
-        # Check user preferences (default: all enabled)
-        pref_col = _NOTIF_PREF_MAP.get(category, "system_notify")
-        try:
-            pref = await env.DB.prepare(
-                f"SELECT {pref_col} AS enabled FROM notification_preferences"
-                " WHERE user_id = ?"
-            ).bind(user_id).first()
-            if pref and not pref.enabled:
-                return  # user opted out of this category
-        except Exception:
-            pass  # table may not exist yet; default to enabled
+        if not skip_pref_check:
+            try:
+                pref = await env.DB.prepare(
+                    "SELECT enrollment_notify, session_notify, system_notify"
+                    " FROM notification_preferences WHERE user_id = ?"
+                ).bind(user_id).first()
+                if pref:
+                    col = _NOTIF_PREF_MAP.get(category, "system_notify")
+                    if not bool(getattr(pref, col, 1)):
+                        return
+            except Exception:
+                pass  # table may not exist yet; default to enabled
 
         enc = env.ENCRYPTION_KEY
         await env.DB.prepare(
@@ -2394,8 +2429,7 @@ async def _create_notification(env, user_id: str, type_: str, title: str,
                await encrypt_aes(message, enc),
                related_id).run()
     except Exception as exc:
-        print(f"[_create_notification ERROR] {type(exc).__name__}: {exc}")
-        return f"{type(exc).__name__}: {exc}"
+        await capture_exception(exc, _env=env, where="_create_notification")
     return None
 
 
@@ -2560,7 +2594,7 @@ async def api_patch_notification_preferences(req, env):
             updates[key] = 1 if val else 0
 
     if not updates:
-        return err("No valid fields to update")
+        return err("Provide at least one of: enrollment_notify, session_notify, system_notify")
 
     # Read current prefs (or defaults)
     current = await env.DB.prepare(

--- a/src/worker.py
+++ b/src/worker.py
@@ -2386,14 +2386,14 @@ async def _on_activity_created(env, p: dict) -> None:
 @_event_handler("ACTIVITY_TAGS_UPDATED")
 async def _on_activity_tags_updated(env, p: dict) -> None:
     recipient_ids = p.get("recipient_ids") or []
-    pref_map = await _get_pref_map(env, recipient_ids, "enrollment_notify")
+    pref_map = await _get_pref_map(env, recipient_ids, "system_notify")
     for uid in recipient_ids:
         if pref_map is not None and pref_map.get(uid) is False:
             continue
         await _create_notification(
             env, uid, "info", f"Activity Updated: {p['activity_title']}",
             f"New tags were added to '{p['activity_title']}'.",
-            related_id=p["activity_id"], category="enrollment", skip_pref_check=True,
+            related_id=p["activity_id"], category="system", skip_pref_check=True,
         )
 
 

--- a/tests/test_join_idempotent.py
+++ b/tests/test_join_idempotent.py
@@ -1,0 +1,36 @@
+"""
+Tests to ensure join is idempotent and does not trigger notifications twice.
+"""
+
+import json
+from tests.helpers import load_worker, MockRow, MockDB, make_env, make_stmt, json_request
+
+worker = load_worker()
+JWT = "test-jwt-secret"
+
+
+def _auth_header(uid="user-1", username="alice", role="member"):
+    token = worker.create_token(uid, username, role, JWT)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _parse(resp):
+    return json.loads(resp.body)
+
+
+class TestJoinIdempotent:
+    async def test_join_second_time_no_notifications(self):
+        act = MockRow(id="act-1", title="Activity", host_id="host-1")
+        existing = MockRow(id="enr-1")
+        stmt_act = make_stmt(first=act)
+        stmt_existing = make_stmt(first=existing)
+        env = make_env(db=MockDB([stmt_act, stmt_existing]), jwt_secret=JWT)
+        req = json_request(
+            "/api/join",
+            {"activity_id": "act-1", "role": "participant"},
+            headers=_auth_header(),
+        )
+        resp = await worker.api_join(req, env)
+        assert resp.status == 200
+        assert _parse(resp)["message"] == "Already joined this activity"
+        assert env.DB._idx == 2

--- a/tests/test_join_idempotent.py
+++ b/tests/test_join_idempotent.py
@@ -3,6 +3,8 @@ Tests to ensure join is idempotent and does not trigger notifications twice.
 """
 
 import json
+from unittest.mock import AsyncMock, MagicMock
+
 from tests.helpers import load_worker, MockRow, MockDB, make_env, make_stmt, json_request
 
 worker = load_worker()
@@ -21,10 +23,13 @@ def _parse(resp):
 class TestJoinIdempotent:
     async def test_join_second_time_no_notifications(self):
         act = MockRow(id="act-1", title="Activity", host_id="host-1")
-        existing = MockRow(id="enr-1")
         stmt_act = make_stmt(first=act)
-        stmt_existing = make_stmt(first=existing)
-        env = make_env(db=MockDB([stmt_act, stmt_existing]), jwt_secret=JWT)
+        stmt_insert = make_stmt()
+        stmt_insert.bind.return_value.run = AsyncMock(
+            return_value=MagicMock(meta=MagicMock(changes=0))
+        )
+        stmt_unused = make_stmt()
+        env = make_env(db=MockDB([stmt_act, stmt_insert, stmt_unused]), jwt_secret=JWT)
         req = json_request(
             "/api/join",
             {"activity_id": "act-1", "role": "participant"},
@@ -34,3 +39,4 @@ class TestJoinIdempotent:
         assert resp.status == 200
         assert _parse(resp)["message"] == "Already joined this activity"
         assert env.DB._idx == 2
+        assert not stmt_unused.bind.called

--- a/tests/test_notification_preferences.py
+++ b/tests/test_notification_preferences.py
@@ -1,0 +1,75 @@
+"""
+Tests for notification preferences endpoints.
+"""
+
+import json
+from tests.helpers import load_worker, MockRequest, MockRow, MockDB, make_env, make_stmt
+
+worker = load_worker()
+JWT = "test-jwt-secret"
+
+
+def _parse(resp):
+    return json.loads(resp.body)
+
+
+def _auth_header(uid="uid-1", username="alice", role="member"):
+    token = worker.create_token(uid, username, role, JWT)
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestNotificationPreferences:
+    async def test_get_defaults(self):
+        stmt = make_stmt(first=None)
+        env = make_env(db=MockDB([stmt]), jwt_secret=JWT)
+        req = MockRequest(
+            method="GET",
+            url="http://localhost/api/notification-preferences",
+            headers=_auth_header(),
+        )
+        resp = await worker.api_get_notification_preferences(req, env)
+        body = _parse(resp)
+        assert resp.status == 200
+        assert body["data"]["enrollment_notify"] is True
+        assert body["data"]["session_notify"] is True
+        assert body["data"]["system_notify"] is True
+
+    async def test_patch_partial_update(self):
+        current = MockRow(enrollment_notify=0, session_notify=1, system_notify=1)
+        stmt_select = make_stmt(first=current)
+        stmt_upsert = make_stmt()
+        env = make_env(db=MockDB([stmt_select, stmt_upsert]), jwt_secret=JWT)
+        req = MockRequest(
+            method="PATCH",
+            url="http://localhost/api/notification-preferences",
+            headers={**_auth_header(), "Content-Type": "application/json"},
+            body=json.dumps({"enrollment_notify": True}),
+        )
+        resp = await worker.api_patch_notification_preferences(req, env)
+        body = _parse(resp)
+        assert resp.status == 200
+        assert body["data"]["enrollment_notify"] is True
+        assert body["data"]["session_notify"] is True
+        assert body["data"]["system_notify"] is True
+
+    async def test_patch_invalid_boolean(self):
+        env = make_env(jwt_secret=JWT)
+        req = MockRequest(
+            method="PATCH",
+            url="http://localhost/api/notification-preferences",
+            headers={**_auth_header(), "Content-Type": "application/json"},
+            body=json.dumps({"session_notify": "yes"}),
+        )
+        resp = await worker.api_patch_notification_preferences(req, env)
+        assert resp.status == 400
+
+    async def test_patch_requires_auth(self):
+        env = make_env(jwt_secret=JWT)
+        req = MockRequest(
+            method="PATCH",
+            url="http://localhost/api/notification-preferences",
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({"session_notify": True}),
+        )
+        resp = await worker.api_patch_notification_preferences(req, env)
+        assert resp.status == 401

--- a/tests/test_notification_preferences.py
+++ b/tests/test_notification_preferences.py
@@ -34,6 +34,12 @@ class TestNotificationPreferences:
         assert body["data"]["session_notify"] is True
         assert body["data"]["system_notify"] is True
 
+    async def test_get_requires_auth(self):
+        env = make_env(jwt_secret=JWT)
+        req = MockRequest(method="GET", url="http://localhost/api/notification-preferences")
+        resp = await worker.api_get_notification_preferences(req, env)
+        assert resp.status == 401
+
     async def test_patch_partial_update(self):
         current = MockRow(enrollment_notify=0, session_notify=1, system_notify=1)
         stmt_select = make_stmt(first=current)
@@ -51,6 +57,8 @@ class TestNotificationPreferences:
         assert body["data"]["enrollment_notify"] is True
         assert body["data"]["session_notify"] is True
         assert body["data"]["system_notify"] is True
+        assert stmt_upsert.bind.called
+        assert stmt_upsert.bind.call_args[0] == ("uid-1", 1, 1, 1)
 
     async def test_patch_invalid_boolean(self):
         env = make_env(jwt_secret=JWT)

--- a/tests/test_notification_triggers.py
+++ b/tests/test_notification_triggers.py
@@ -1,0 +1,86 @@
+"""
+Tests for notification triggers on register/join/create_session.
+"""
+
+import json
+from tests.helpers import load_worker, MockRow, MockDB, make_env, make_stmt, json_request
+
+worker = load_worker()
+JWT = "test-jwt-secret"
+
+
+def _auth_header(uid="uid-1", username="alice", role="member"):
+    token = worker.create_token(uid, username, role, JWT)
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestNotificationTriggers:
+    async def test_join_creates_notifications(self):
+        act = MockRow(id="act-1", title="Activity", host_id="host-1")
+        stmt_act = make_stmt(first=act)
+        stmt_existing = make_stmt(first=None)
+        stmt_insert = make_stmt()
+        stmt_participant = make_stmt(first=MockRow(name="v1:"))
+        stmt_pref_select_1 = make_stmt(first=None)
+        stmt_notif_insert_1 = make_stmt()
+        stmt_pref_select_2 = make_stmt(first=None)
+        stmt_notif_insert_2 = make_stmt()
+        env = make_env(
+            db=MockDB([
+                stmt_act,
+                stmt_existing,
+                stmt_insert,
+                stmt_participant,
+                stmt_pref_select_1,
+                stmt_notif_insert_1,
+                stmt_pref_select_2,
+                stmt_notif_insert_2,
+            ]),
+            jwt_secret=JWT,
+        )
+        req = json_request(
+            "/api/join",
+            {"activity_id": "act-1", "role": "participant"},
+            headers=_auth_header(uid="user-1", username="bob"),
+        )
+        resp = await worker.api_join(req, env)
+        assert resp.status == 200
+        assert stmt_notif_insert_1.bind.return_value.run.called
+        assert stmt_notif_insert_2.bind.return_value.run.called
+
+    async def test_create_session_creates_notifications(self):
+        owned = MockRow(id="act-1")
+        act_row = MockRow(title="Activity")
+        enrollee_rows = [MockRow(user_id="user-2")]
+        stmt_owned = make_stmt(first=owned)
+        stmt_insert_session = make_stmt()
+        stmt_act_title = make_stmt(first=act_row)
+        stmt_enrollees = make_stmt(all_results=enrollee_rows)
+        stmt_pref_select = make_stmt(first=None)
+        stmt_notif_insert = make_stmt()
+        env = make_env(
+            db=MockDB([
+                stmt_owned,
+                stmt_insert_session,
+                stmt_act_title,
+                stmt_enrollees,
+                stmt_pref_select,
+                stmt_notif_insert,
+            ]),
+            jwt_secret=JWT,
+        )
+        req = json_request(
+            "/api/sessions",
+            {
+                "activity_id": "act-1",
+                "title": "Session 1",
+                "description": "desc",
+                "start_time": "2026-05-30 10:00",
+                "end_time": "2026-05-30 11:00",
+                "location": "Room",
+            },
+            headers=_auth_header(uid="host-1", username="host"),
+        )
+        resp = await worker.api_create_session(req, env)
+        assert resp.status == 200
+        assert stmt_notif_insert.bind.return_value.run.called

--- a/tests/test_notification_triggers.py
+++ b/tests/test_notification_triggers.py
@@ -2,7 +2,8 @@
 Tests for notification triggers on register/join/create_session.
 """
 
-import json
+from unittest.mock import AsyncMock, MagicMock
+
 from tests.helpers import load_worker, MockRow, MockDB, make_env, make_stmt, json_request
 
 worker = load_worker()
@@ -18,9 +19,11 @@ class TestNotificationTriggers:
     async def test_join_creates_notifications(self):
         act = MockRow(id="act-1", title="Activity", host_id="host-1")
         stmt_act = make_stmt(first=act)
-        stmt_existing = make_stmt(first=None)
         stmt_insert = make_stmt()
-        stmt_participant = make_stmt(first=MockRow(name="v1:"))
+        stmt_insert.bind.return_value.run = AsyncMock(
+            return_value=MagicMock(meta=MagicMock(changes=1))
+        )
+        stmt_name = make_stmt(first=MockRow(name="v1:Bob"))
         stmt_pref_select_1 = make_stmt(first=None)
         stmt_notif_insert_1 = make_stmt()
         stmt_pref_select_2 = make_stmt(first=None)
@@ -28,9 +31,8 @@ class TestNotificationTriggers:
         env = make_env(
             db=MockDB([
                 stmt_act,
-                stmt_existing,
                 stmt_insert,
-                stmt_participant,
+                stmt_name,
                 stmt_pref_select_1,
                 stmt_notif_insert_1,
                 stmt_pref_select_2,
@@ -47,6 +49,8 @@ class TestNotificationTriggers:
         assert resp.status == 200
         assert stmt_notif_insert_1.bind.return_value.run.called
         assert stmt_notif_insert_2.bind.return_value.run.called
+        assert stmt_notif_insert_1.bind.call_args[0][1] == "user-1"
+        assert stmt_notif_insert_2.bind.call_args[0][1] == "host-1"
 
     async def test_create_session_creates_notifications(self):
         owned = MockRow(id="act-1")
@@ -56,7 +60,7 @@ class TestNotificationTriggers:
         stmt_insert_session = make_stmt()
         stmt_act_title = make_stmt(first=act_row)
         stmt_enrollees = make_stmt(all_results=enrollee_rows)
-        stmt_pref_select = make_stmt(first=None)
+        stmt_pref_batch = make_stmt(all_results=[])
         stmt_notif_insert = make_stmt()
         env = make_env(
             db=MockDB([
@@ -64,7 +68,7 @@ class TestNotificationTriggers:
                 stmt_insert_session,
                 stmt_act_title,
                 stmt_enrollees,
-                stmt_pref_select,
+                stmt_pref_batch,
                 stmt_notif_insert,
             ]),
             jwt_secret=JWT,
@@ -84,3 +88,4 @@ class TestNotificationTriggers:
         resp = await worker.api_create_session(req, env)
         assert resp.status == 200
         assert stmt_notif_insert.bind.return_value.run.called
+        assert stmt_notif_insert.bind.call_args[0][1] == "user-2"

--- a/tests/test_notifications_api.py
+++ b/tests/test_notifications_api.py
@@ -50,6 +50,21 @@ class TestNotificationsApi:
         assert body["data"]["unread_count"] == 1
         assert body["data"]["notifications"][0]["title"] == "Welcome"
 
+    async def test_list_pagination_params(self):
+        stmt_list = make_stmt(all_results=[])
+        stmt_count = make_stmt(first=MockRow(cnt=0))
+        env = make_env(db=MockDB([stmt_list, stmt_count]), jwt_secret=JWT)
+        req = MockRequest(
+            method="GET",
+            url="http://localhost/api/notifications?unread_only=true&limit=5&offset=10",
+            headers=_auth_header(),
+        )
+        resp = await worker.api_list_notifications(req, env)
+        body = _parse(resp)
+        assert resp.status == 200
+        assert body["data"]["limit"] == 5
+        assert body["data"]["offset"] == 10
+
     async def test_list_requires_auth(self):
         env = make_env(jwt_secret=JWT)
         req = MockRequest(method="GET", url="http://localhost/api/notifications")
@@ -86,6 +101,7 @@ class TestNotificationsApi:
         )
         resp = await worker.api_mark_notification_read(req, env, "n1")
         assert resp.status == 200
+        assert stmt_update.bind.return_value.run.called
 
     async def test_mark_one_read_404(self):
         stmt_select = make_stmt(first=None)
@@ -114,6 +130,7 @@ class TestNotificationsApi:
         )
         resp = await worker.api_mark_all_read(req, env)
         assert resp.status == 200
+        assert stmt_update.bind.return_value.run.called
 
     async def test_mark_all_requires_auth(self):
         env = make_env(jwt_secret=JWT)

--- a/tests/test_notifications_api.py
+++ b/tests/test_notifications_api.py
@@ -1,0 +1,122 @@
+"""
+Tests for notifications API endpoints.
+"""
+
+import base64
+import json
+from tests.helpers import load_worker, MockRequest, MockRow, MockDB, make_env, make_stmt
+
+worker = load_worker()
+
+JWT = "test-jwt-secret"
+
+
+def _parse(resp):
+    return json.loads(resp.body)
+
+
+def _enc(val: str) -> str:
+    iv = b"\x00" * 12
+    return "v1:" + base64.b64encode(iv + val.encode("utf-8")).decode("ascii")
+
+
+def _auth_header(uid="uid-1", username="alice", role="member"):
+    token = worker.create_token(uid, username, role, JWT)
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestNotificationsApi:
+    async def test_list_notifications(self):
+        row = MockRow(
+            id="n1",
+            type="info",
+            title=_enc("Welcome"),
+            message=_enc("Hi"),
+            is_read=0,
+            related_id=None,
+            created_at="2026-05-30 10:00",
+        )
+        stmt_list = make_stmt(all_results=[row])
+        stmt_count = make_stmt(first=MockRow(cnt=1))
+        env = make_env(db=MockDB([stmt_list, stmt_count]), jwt_secret=JWT)
+        req = MockRequest(
+            method="GET",
+            url="http://localhost/api/notifications",
+            headers=_auth_header(),
+        )
+        resp = await worker.api_list_notifications(req, env)
+        body = _parse(resp)
+        assert resp.status == 200
+        assert body["data"]["unread_count"] == 1
+        assert body["data"]["notifications"][0]["title"] == "Welcome"
+
+    async def test_list_requires_auth(self):
+        env = make_env(jwt_secret=JWT)
+        req = MockRequest(method="GET", url="http://localhost/api/notifications")
+        resp = await worker.api_list_notifications(req, env)
+        assert resp.status == 401
+
+    async def test_unread_count(self):
+        stmt = make_stmt(first=MockRow(cnt=3))
+        env = make_env(db=MockDB([stmt]), jwt_secret=JWT)
+        req = MockRequest(
+            method="GET",
+            url="http://localhost/api/notifications/unread-count",
+            headers=_auth_header(),
+        )
+        resp = await worker.api_unread_count(req, env)
+        body = _parse(resp)
+        assert resp.status == 200
+        assert body["data"]["unread_count"] == 3
+
+    async def test_unread_count_requires_auth(self):
+        env = make_env(jwt_secret=JWT)
+        req = MockRequest(method="GET", url="http://localhost/api/notifications/unread-count")
+        resp = await worker.api_unread_count(req, env)
+        assert resp.status == 401
+
+    async def test_mark_one_read(self):
+        stmt_select = make_stmt(first=MockRow(id="n1"))
+        stmt_update = make_stmt()
+        env = make_env(db=MockDB([stmt_select, stmt_update]), jwt_secret=JWT)
+        req = MockRequest(
+            method="POST",
+            url="http://localhost/api/notifications/n1/read",
+            headers=_auth_header(),
+        )
+        resp = await worker.api_mark_notification_read(req, env, "n1")
+        assert resp.status == 200
+
+    async def test_mark_one_read_404(self):
+        stmt_select = make_stmt(first=None)
+        env = make_env(db=MockDB([stmt_select]), jwt_secret=JWT)
+        req = MockRequest(
+            method="POST",
+            url="http://localhost/api/notifications/bad/read",
+            headers=_auth_header(),
+        )
+        resp = await worker.api_mark_notification_read(req, env, "bad")
+        assert resp.status == 404
+
+    async def test_mark_one_requires_auth(self):
+        env = make_env(jwt_secret=JWT)
+        req = MockRequest(method="POST", url="http://localhost/api/notifications/n1/read")
+        resp = await worker.api_mark_notification_read(req, env, "n1")
+        assert resp.status == 401
+
+    async def test_mark_all_read(self):
+        stmt_update = make_stmt()
+        env = make_env(db=MockDB([stmt_update]), jwt_secret=JWT)
+        req = MockRequest(
+            method="POST",
+            url="http://localhost/api/notifications/read-all",
+            headers=_auth_header(),
+        )
+        resp = await worker.api_mark_all_read(req, env)
+        assert resp.status == 200
+
+    async def test_mark_all_requires_auth(self):
+        env = make_env(jwt_secret=JWT)
+        req = MockRequest(method="POST", url="http://localhost/api/notifications/read-all")
+        resp = await worker.api_mark_all_read(req, env)
+        assert resp.status == 401


### PR DESCRIPTION
-Add notification preferences and API endpoints.
-Wire notifications to enrollments, sessions, activities, and tag updates.
-Improve notifications UI with polling, unread badge, and preferences page.
-Add tests for notifications API, preferences, triggers, and idempotent join.

## Changes
### Backend

-Add notification_preferences table and DDL.
-Add GET/PATCH /api/notification-preferences.
-Add events for enrollment, session creation, activity creation, and tag updates.
-Guard against duplicate enrollment notifications.
-Include participant name in host enrollment notifications.
-Pagination with [limit]/[offset]and decrypt titles/messages on read.

### Frontend

-Notifications page with unread filter, mark‑read/all, polling refresh.
-Preferences page with three toggles (enrollment/session/system).
-Navbar bell link and unread badge.

### Tests

-Notifications API coverage (list, unread count, mark one/all, auth/404).
-Preferences API coverage (GET defaults, PATCH partial, validation).
-Trigger coverage (join + session create).
-Idempotent join test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Purpose
Implements a full notifications system: backend schema, event wiring, APIs, encrypted storage/decryption, frontend UI (notifications + preferences + navbar integration), polling/caching UX, and tests to cover API behavior and event triggers.

## Key modifications

### Backend
- New table: notification_preferences(user_id, enrollment_notify, session_notify, system_notify, updated_at) with ON DELETE CASCADE.
- Event wiring: emits USER_ENROLLED, SESSION_CREATED, ACTIVITY_CREATED, ACTIVITY_TAGS_UPDATED from join, session creation, activity creation, and tag updates. Handlers create per-user notifications honoring preferences and avoiding duplicate enrollment notifications.
- New/updated endpoints:
  - GET /api/notification-preferences — returns per-user toggles
  - PATCH /api/notification-preferences — partial update with boolean validation and upsert
  - GET /api/notifications — supports limit/offset pagination, unread_only filter, returns unread_count; decrypts notifications for responses and when marking read
  - POST /api/notifications/{id}/read and POST /api/notifications/read-all — mark single/all read
- Encryption/decryption: added decrypt_aes_with_key (AES-GCM using imported WebCrypto key) with legacy XOR fallback; notifications are stored encrypted and decrypted when read/listed as implemented.
- Idempotency: /api/join detects existing enrollment (INSERT OR IGNORE + changes) to prevent duplicate notifications.
- Misc: broadened CORS (PATCH/DELETE) and introduced static cache-control helper.

### Frontend
- Notifications page (public/notifications.html):
  - Paginated list, All/Unread filter, "Mark read" per-item and "Mark all read" actions.
  - Local cache (30s TTL) for initial non-filtered load.
  - Background synchronization (silentRefresh) to insert new items and reconcile read state; polling tied to visibility (timer ~10s).
  - Unread header badge updated from API responses; list actions refresh state after mark-read operations.
- Preferences page (public/notification-preferences.html):
  - UI with three toggles (enrollment, session, system); loads via GET and saves via PATCH with error handling.
- Navbar/layout (public/js/layout.js, partials):
  - Bell links to /notifications.html, unread badge element (notif-unread-badge).
  - Layout refactored into async initLayout; exposes window.refreshUnreadBadge, startUnreadPolling, stopUnreadPolling, applyUnreadBadgeCount.
  - Unread-count polling on login via refreshUnreadBadge every 5s; polling stopped on logout.

### Tests
- tests covering API behavior and event triggers:
  - tests/test_notifications_api.py — list (with pagination), unread count, mark-one/read-all, auth/404 cases, decryption checks.
  - tests/test_notification_preferences.py — GET defaults, PATCH partial update, validation, auth enforcement.
  - tests/test_notification_triggers.py — ensures join and session creation emit expected notification inserts and recipient bindings.
  - tests/test_join_idempotent.py — verifies idempotent join behavior prevents duplicate notifications.

## Impact
- UX: Real-time unread indicators, per-category preference controls, and convenient per-item and bulk read actions improve user visibility and control.
- Data integrity: Enrollment idempotency prevents duplicate notifications; preference checks reduce unwanted notifications.
- Performance: Pagination, short client-side cache, and selective background sync reduce load; AES key import optimizes decryption paths.
- Security: Notifications stored encrypted; endpoints require auth; decryption performed server-side with AES-GCM and legacy fallback handled safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->