### PR TITLE
Add D1 migrations and migrate.sh for notifications tables

### DIFF
--- a/migrate.sh
+++ b/migrate.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+echo "Applying D1 migrations to education_db..."
+npx wrangler d1 migrations apply education_db --remote
+echo "Done."

--- a/migrate.sh
+++ b/migrate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 echo "Applying D1 migrations to education_db..."
-npx wrangler d1 migrations apply education_db --remote
+npx --yes wrangler d1 migrations apply education_db --remote
 echo "Done."

--- a/migrations/0001_initial_schema.sql
+++ b/migrations/0001_initial_schema.sql
@@ -1,0 +1,81 @@
+-- Migration 0001: Initial schema
+
+CREATE TABLE IF NOT EXISTS users (
+    id            TEXT PRIMARY KEY,
+    username_hash TEXT NOT NULL UNIQUE,
+    email_hash    TEXT NOT NULL UNIQUE,
+    name          TEXT NOT NULL,
+    username      TEXT NOT NULL,
+    email         TEXT NOT NULL,
+    password_hash TEXT NOT NULL,
+    role          TEXT NOT NULL,
+    created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS activities (
+    id            TEXT PRIMARY KEY,
+    title         TEXT NOT NULL,
+    description   TEXT,
+    type          TEXT NOT NULL DEFAULT 'course',
+    format        TEXT NOT NULL DEFAULT 'self_paced',
+    schedule_type TEXT NOT NULL DEFAULT 'ongoing',
+    host_id       TEXT NOT NULL,
+    created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (host_id) REFERENCES users(id)
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id          TEXT PRIMARY KEY,
+    activity_id TEXT NOT NULL,
+    title       TEXT,
+    description TEXT,
+    start_time  TEXT,
+    end_time    TEXT,
+    location    TEXT,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (activity_id) REFERENCES activities(id)
+);
+
+CREATE TABLE IF NOT EXISTS enrollments (
+    id          TEXT PRIMARY KEY,
+    activity_id TEXT NOT NULL,
+    user_id     TEXT NOT NULL,
+    role        TEXT NOT NULL DEFAULT 'participant',
+    status      TEXT NOT NULL DEFAULT 'active',
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (activity_id, user_id),
+    FOREIGN KEY (activity_id) REFERENCES activities(id),
+    FOREIGN KEY (user_id)     REFERENCES users(id)
+);
+
+CREATE TABLE IF NOT EXISTS session_attendance (
+    id         TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    user_id    TEXT NOT NULL,
+    status     TEXT NOT NULL DEFAULT 'registered',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (session_id, user_id),
+    FOREIGN KEY (session_id) REFERENCES sessions(id),
+    FOREIGN KEY (user_id)    REFERENCES users(id)
+);
+
+CREATE TABLE IF NOT EXISTS tags (
+    id   TEXT PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS activity_tags (
+    activity_id TEXT NOT NULL,
+    tag_id      TEXT NOT NULL,
+    PRIMARY KEY (activity_id, tag_id),
+    FOREIGN KEY (activity_id) REFERENCES activities(id),
+    FOREIGN KEY (tag_id)      REFERENCES tags(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_activities_host         ON activities(host_id);
+CREATE INDEX IF NOT EXISTS idx_enrollments_activity    ON enrollments(activity_id);
+CREATE INDEX IF NOT EXISTS idx_enrollments_user        ON enrollments(user_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_activity       ON sessions(activity_id);
+CREATE INDEX IF NOT EXISTS idx_sa_session              ON session_attendance(session_id);
+CREATE INDEX IF NOT EXISTS idx_sa_user                 ON session_attendance(user_id);
+CREATE INDEX IF NOT EXISTS idx_at_activity             ON activity_tags(activity_id);

--- a/migrations/0002_add_notifications.sql
+++ b/migrations/0002_add_notifications.sql
@@ -1,0 +1,26 @@
+-- Migration 0002: Add notifications and notification_preferences tables
+
+CREATE TABLE IF NOT EXISTS notifications (
+    id         TEXT PRIMARY KEY,
+    user_id    TEXT NOT NULL,
+    type       TEXT NOT NULL,
+    title      TEXT NOT NULL,
+    message    TEXT NOT NULL,
+    is_read    INTEGER NOT NULL DEFAULT 0,
+    related_id TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_notif_user    ON notifications(user_id);
+CREATE INDEX IF NOT EXISTS idx_notif_unread  ON notifications(user_id, is_read);
+CREATE INDEX IF NOT EXISTS idx_notif_created ON notifications(user_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS notification_preferences (
+    user_id           TEXT PRIMARY KEY,
+    enrollment_notify INTEGER NOT NULL DEFAULT 1,
+    session_notify    INTEGER NOT NULL DEFAULT 1,
+    system_notify     INTEGER NOT NULL DEFAULT 1,
+    updated_at        TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -16,6 +16,7 @@ not_found_handling = "404-page"
 binding = "DB"
 database_name = "education_db"
 database_id = "a0021f2e-a8cc-4e20-8910-3c7290ba47a6"
+migrations_dir = "migrations"
 
 
 # Virtual Classroom Durable Object
@@ -50,3 +51,6 @@ invocation_logs = true
 enabled = false
 persist = true
 head_sampling_rate = 1
+
+[build]
+command = "bash migrate.sh"


### PR DESCRIPTION
Added migrations/ folder with two migration files, migrate.sh, and wired [build] command = "bash migrate.sh" into wrangler.toml so migrations run automatically on every deploy.
Also added migrations_dir = "migrations" so Wrangler tracks applied migrations. 
Tested locally — 0001 and 0002 apply cleanly. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR establishes a structured D1 database migration system for the project by introducing automated migration management with two SQL migration files, a migration runner script, and wrangler configuration updates.

## Key Changes

### Migration Files
- **0001_initial_schema.sql**: Creates the foundational database schema including `users`, `activities`, `sessions`, `enrollments`, `session_attendance`, `tags`, and `activity_tags` tables with appropriate foreign keys, indexes, and default timestamps.
- **0002_add_notifications.sql**: Adds notification functionality with `notifications` and `notification_preferences` tables, enabling users to receive and manage notification preferences across enrollment, session, and system event types.

### Migration Infrastructure
- **migrate.sh**: Bash script that applies D1 migrations to `education_db` using `npx wrangler d1 migrations apply education_db --remote`, with error handling and status logging.
- **wrangler.toml**: Updated to:
  - Define `migrations_dir = "migrations"` for Wrangler to track applied migrations
  - Add `[build]` section with `command = "bash migrate.sh"` to automatically apply migrations on every deployment

## Impact
- Enables consistent database schema versioning and automated deployment of database changes across environments
- Introduces notification infrastructure supporting multi-type notifications with user preferences and read status tracking
- Ensures migrations run with proper error handling and remote database synchronization during builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->