### PR TITLE
study groups under activities

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -183,9 +183,10 @@ if (!token || !user) {
 }
 
 // Type icons and colors
-const typeIcon = { course: '📚', meetup: '🤝', workshop: '🔧', seminar: '🎤', other: '✨' };
+const typeIcon = { course: '📚', study_group: '👥', meetup: '🤝', workshop: '🔧', seminar: '🎤', other: '✨' };
 const typeColor = {
     course: 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300',
+    study_group: 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300',
     meetup: 'bg-pink-100 dark:bg-pink-900/30 text-pink-700 dark:text-pink-300',
     workshop: 'bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300',
     seminar: 'bg-teal-100 dark:bg-teal-900/30 text-teal-700 dark:text-teal-300',

--- a/public/teach.html
+++ b/public/teach.html
@@ -79,7 +79,7 @@
                     Create & Manage Your Activities
                 </h1>
                 <p class="text-lg md:text-xl text-orange-50 max-w-2xl mx-auto mb-8">
-                    Host courses, workshops, meetups, clubs, events, videos, and seminars. Reach learners worldwide and build your teaching community.
+                    Host courses, study groups, workshops, meetups, clubs, events, videos, and seminars. Reach learners worldwide and build your teaching community.
                 </p>
                 <a href="#host-content" class="inline-flex items-center gap-2 bg-white text-orange-600 font-bold px-8 py-3 rounded-xl shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all duration-300">
                     <i class="fas fa-arrow-down"></i>
@@ -128,6 +128,7 @@
                                 <label class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">Type</label>
                                 <select id="a-type" class="w-full px-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 dark:bg-gray-700 dark:text-white text-sm">
                                     <option value="course">📚 Course</option>
+                                    <option value="study_group">👥 Study Group</option>
                                     <option value="workshop">🔧 Workshop</option>
                                     <option value="meetup">🤝 Meetup</option>
                                     <option value="seminar">🎤 Seminar</option>
@@ -278,9 +279,10 @@ function logout() {
 }
 
 // Type icons and colors
-const typeIcon = { course: '📚', meetup: '🤝', workshop: '🔧', seminar: '🎤', club: '🏛', event: '📅', video: '🎬', other: '✨' };
+const typeIcon = { course: '📚', study_group: '👥', meetup: '🤝', workshop: '🔧', seminar: '🎤', club: '🏛', event: '📅', video: '🎬', other: '✨' };
 const typeColor = {
     course: 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300',
+    study_group: 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300',
     meetup: 'bg-pink-100 dark:bg-pink-900/30 text-pink-700 dark:text-pink-300',
     workshop: 'bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300',
     seminar: 'bg-teal-100 dark:bg-teal-900/30 text-teal-700 dark:text-teal-300',

--- a/src/worker.py
+++ b/src/worker.py
@@ -2909,15 +2909,6 @@ SSR_RECORD_PAGES = {
         "noun": "posts",
         "private": False,
     },
-    "/study-groups": {
-        "title": "Study Groups",
-        "kicker": "Learn together",
-        "description": "Browse study groups and group invitations from the learning community.",
-        "group": "community",
-        "models": ["web.StudyGroup", "web.StudyGroupInvite"],
-        "noun": "groups",
-        "private": False,
-    },
     "/quizzes": {
         "title": "Quizzes",
         "kicker": "Assessments",
@@ -3129,7 +3120,7 @@ def _language_prefixed_target(path: str) -> Optional[str]:
 
     if route in LEGACY_LANGUAGE_ROUTE_ALIASES:
         return LEGACY_LANGUAGE_ROUTE_ALIASES[route]
-    for old_prefix, new_prefix in (("/courses/", "/activity/"), ("/course/", "/activity/"), ("/classes/", "/activity/")):
+    for old_prefix, new_prefix in (("/courses/", "/activity/"), ("/course/", "/activity/"), ("/classes/", "/activity/"), ("/study-groups/", "/activity/"), ("/study-group/", "/activity/")):
         if route.startswith(old_prefix):
             return new_prefix + route[len(old_prefix):]
 
@@ -6092,6 +6083,9 @@ async def _dispatch(request, env):
     route_path = path[:-5] if path.endswith(".html") else path
     if len(route_path) > 1 and route_path.endswith("/"):
         route_path = route_path.rstrip("/")
+    m_study_group = re.fullmatch(r"/study-groups?/([^/]+)", route_path)
+    if method == "GET" and m_study_group:
+        return _redirect_to_current_route(request, f"/activity/{m_study_group.group(1)}")
     if method == "GET" and route_path in ("/activity", "/activity.html"):
         activity_query = parse_qs(urlparse(request.url).query)
         if activity_query.get("slug") or activity_query.get("id"):

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -280,3 +280,10 @@ class TestStudyGroupRedirection:
         r = await worker._dispatch(req, env)
         assert r.status == 302
         assert r.headers.get("Location") == "http://localhost/activity/my-awesome-group"
+
+    async def test_study_group_singular_slug_redirects_to_activity_slug(self):
+        env = make_env()
+        req = MockRequest(method="GET", url="http://localhost/study-group/my-awesome-group")
+        r = await worker._dispatch(req, env)
+        assert r.status == 302
+        assert r.headers.get("Location") == "http://localhost/activity/my-awesome-group"

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -257,3 +257,26 @@ class TestInitAndSeedRouting:
         req = MockRequest(method="GET", url="http://localhost/api/init")
         r = await worker._dispatch(req, env)
         assert r.status == 404
+
+# Study groups redirection
+class TestStudyGroupRedirection:
+    async def test_study_groups_serves_static_page(self):
+        env = make_env()
+        set_static_content(env, "<html>study groups</html>")
+        req = MockRequest(method="GET", url="http://localhost/study-groups")
+        r = await worker._dispatch(req, env)
+        assert r.status == 200
+
+    async def test_study_groups_html_serves_static_page(self):
+        env = make_env()
+        set_static_content(env, "<html>study groups</html>")
+        req = MockRequest(method="GET", url="http://localhost/study-groups.html")
+        r = await worker._dispatch(req, env)
+        assert r.status == 200
+
+    async def test_study_group_slug_redirects_to_activity_slug(self):
+        env = make_env()
+        req = MockRequest(method="GET", url="http://localhost/study-groups/my-awesome-group")
+        r = await worker._dispatch(req, env)
+        assert r.status == 302
+        assert r.headers.get("Location") == "http://localhost/activity/my-awesome-group"


### PR DESCRIPTION
 Integrates Study Groups into the Activities engine
 
https://github.com/user-attachments/assets/ff5d8e7a-b715-4cdd-8b04-540ca10b7e7b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Integrated Study Groups into the Activities experience across the UI and routing layers. Updated dashboard and Host Hub activity card metadata so `study_group` uses the correct icon and styling, added “study groups” to the Host Hub description and create-activity type selector, and extended server-side routing to treat study-group URLs as activity routes with redirects for deep links. Added tests covering study-group page serving and redirect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->